### PR TITLE
chore: (maintenance) update build process

### DIFF
--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -1,9 +1,12 @@
-name: Publish Container
+name: Publish Container (Manual)
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build (e.g., v1.0.0)'
+        required: true
+        type: string
 
 env:
   REGISTRY: ghcr.io
@@ -19,6 +22,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
 
       - name: Log in to Container Registry
         uses: docker/login-action@v3
@@ -33,8 +38,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=semver,pattern={{version}}
-            type=raw,value=latest,enable=${{ !github.event.release.prerelease }}
+            type=semver,pattern={{version}},value=${{ inputs.tag }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to release (e.g., 0.1.6, 1.0.0)'
+        description: 'Version to release (e.g., 0.1.6, 1.0.0, 1.0.0-beta.1)'
         required: true
         type: string
       release_type:
@@ -23,6 +23,10 @@ on:
         default: false
         type: boolean
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -32,6 +36,7 @@ jobs:
 
     outputs:
       release_tag: v${{ inputs.version }}
+      previous_tag: ${{ steps.get_previous_tag.outputs.tag }}
 
     steps:
       - name: Checkout repository
@@ -52,8 +57,9 @@ jobs:
 
       - name: Validate version format
         run: |
-          if [[ ! "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Error: Version must be in semver format (e.g., 1.0.0)"
+          # Support: 1.0.0, 1.0.0-alpha.1, 1.0.0-beta.1, 1.0.0-rc.1
+          if [[ ! "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z]+\.[0-9]+)?$ ]]; then
+            echo "Error: Version must be in semver format (e.g., 1.0.0 or 1.0.0-beta.1)"
             exit 1
           fi
 
@@ -63,6 +69,13 @@ jobs:
             echo "Error: Version v${{ inputs.version }} already exists"
             exit 1
           fi
+
+      - name: Get previous tag
+        id: get_previous_tag
+        run: |
+          PREVIOUS_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          echo "tag=${PREVIOUS_TAG}" >> $GITHUB_OUTPUT
+          echo "Previous tag: ${PREVIOUS_TAG:-none}"
 
       - name: Update version in pyproject.toml
         run: |
@@ -85,31 +98,6 @@ jobs:
           print(f'Updated version from {current_version} to {new_version}')
           "
 
-      - name: Generate changelog entry
-        id: changelog
-        run: |
-          # Get commits since last tag
-          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-          if [ -z "$LAST_TAG" ]; then
-            COMMITS=$(git log --oneline --pretty=format:"- %s" HEAD)
-          else
-            COMMITS=$(git log --oneline --pretty=format:"- %s" ${LAST_TAG}..HEAD)
-          fi
-
-          # Create release notes
-          cat > release_notes.md << EOF
-          ## What's Changed
-
-          ${COMMITS}
-
-          **Full Changelog**: https://github.com/${{ github.repository }}/compare/${LAST_TAG}...v${{ inputs.version }}
-          EOF
-
-          # Store for later use
-          echo "release_notes<<EOF" >> $GITHUB_OUTPUT
-          cat release_notes.md >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-
       - name: Configure Git
         run: |
           git config user.name "github-actions[bot]"
@@ -128,17 +116,6 @@ jobs:
         run: |
           git tag v${{ inputs.version }}
           git push origin v${{ inputs.version }}
-
-      - name: Create GitHub release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: v${{ inputs.version }}
-          release_name: Release v${{ inputs.version }}
-          body: ${{ steps.changelog.outputs.release_notes }}
-          draft: false
-          prerelease: ${{ inputs.prerelease }}
 
   build:
     name: Build distribution
@@ -208,7 +185,184 @@ jobs:
       - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
 
-      - name: Success message
+  build-container:
+    name: Build and Push Container
+    needs: [release, publish-to-pypi]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release.outputs.release_tag }}
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}},value=${{ inputs.version }}
+            type=raw,value=latest,enable=${{ inputs.prerelease == false }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  create-release:
+    name: Create GitHub Release
+    needs: [release, build-container]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.release.outputs.release_tag }}
+
+      - name: Generate Conventional Changelog
+        id: changelog
+        env:
+          PREVIOUS_TAG: ${{ needs.release.outputs.previous_tag }}
+          NEW_VERSION: ${{ inputs.version }}
         run: |
-          echo "Release completed successfully!"
-          echo "Published to both TestPyPI and PyPI, and created GitHub release."
+          # Initialize categories
+          FEATURES=""
+          FIXES=""
+          DOCS=""
+          CHORES=""
+          BREAKING=""
+          OTHER=""
+
+          # Get commits since last tag
+          if [ -n "$PREVIOUS_TAG" ]; then
+            echo "Getting commits from ${PREVIOUS_TAG} to HEAD"
+            COMMITS=$(git log --pretty=format:"%s|%h" ${PREVIOUS_TAG}..HEAD 2>/dev/null || echo "")
+          else
+            echo "No previous tag found, getting all commits"
+            COMMITS=$(git log --pretty=format:"%s|%h" 2>/dev/null || echo "")
+          fi
+
+          # Parse each commit by prefix
+          while IFS='|' read -r message hash; do
+            [ -z "$message" ] && continue
+
+            # Check for conventional commit prefixes
+            if [[ "$message" =~ ^feat(\(.+\))?!?:\ (.+) ]]; then
+              FEATURES="${FEATURES}- ${BASH_REMATCH[2]} (\`${hash}\`)\n"
+            elif [[ "$message" =~ ^fix(\(.+\))?!?:\ (.+) ]]; then
+              FIXES="${FIXES}- ${BASH_REMATCH[2]} (\`${hash}\`)\n"
+            elif [[ "$message" =~ ^docs(\(.+\))?:\ (.+) ]]; then
+              DOCS="${DOCS}- ${BASH_REMATCH[2]} (\`${hash}\`)\n"
+            elif [[ "$message" =~ ^chore(\(.+\))?:\ (.+) ]]; then
+              CHORES="${CHORES}- ${BASH_REMATCH[2]} (\`${hash}\`)\n"
+            elif [[ "$message" =~ ^refactor(\(.+\))?:\ (.+) ]]; then
+              CHORES="${CHORES}- ${BASH_REMATCH[2]} (\`${hash}\`)\n"
+            elif [[ "$message" =~ ^test(\(.+\))?:\ (.+) ]]; then
+              CHORES="${CHORES}- ${BASH_REMATCH[2]} (\`${hash}\`)\n"
+            elif [[ "$message" =~ ^ci(\(.+\))?:\ (.+) ]]; then
+              CHORES="${CHORES}- ${BASH_REMATCH[2]} (\`${hash}\`)\n"
+            elif [[ "$message" =~ BREAKING[[:space:]]CHANGE ]]; then
+              BREAKING="${BREAKING}- ${message} (\`${hash}\`)\n"
+            else
+              OTHER="${OTHER}- ${message} (\`${hash}\`)\n"
+            fi
+          done <<< "$COMMITS"
+
+          # Build changelog with non-empty sections
+          echo "## What's Changed" > changelog.md
+          echo "" >> changelog.md
+
+          if [ -n "$BREAKING" ]; then
+            echo "### Breaking Changes" >> changelog.md
+            echo -e "$BREAKING" >> changelog.md
+          fi
+
+          if [ -n "$FEATURES" ]; then
+            echo "### Features" >> changelog.md
+            echo -e "$FEATURES" >> changelog.md
+          fi
+
+          if [ -n "$FIXES" ]; then
+            echo "### Bug Fixes" >> changelog.md
+            echo -e "$FIXES" >> changelog.md
+          fi
+
+          if [ -n "$DOCS" ]; then
+            echo "### Documentation" >> changelog.md
+            echo -e "$DOCS" >> changelog.md
+          fi
+
+          if [ -n "$CHORES" ]; then
+            echo "### Maintenance" >> changelog.md
+            echo -e "$CHORES" >> changelog.md
+          fi
+
+          if [ -n "$OTHER" ]; then
+            echo "### Other" >> changelog.md
+            echo -e "$OTHER" >> changelog.md
+          fi
+
+          # If no categorized changes, add a fallback message
+          if [ -z "$FEATURES" ] && [ -z "$FIXES" ] && [ -z "$DOCS" ] && [ -z "$CHORES" ] && [ -z "$BREAKING" ] && [ -z "$OTHER" ]; then
+            echo "No changes recorded." >> changelog.md
+            echo "" >> changelog.md
+          fi
+
+      - name: Append Installation Info
+        env:
+          VERSION: ${{ inputs.version }}
+          PREVIOUS_TAG: ${{ needs.release.outputs.previous_tag }}
+        run: |
+          cat >> changelog.md << EOF
+
+          ---
+
+          ## Installation
+
+          ### Python Package
+          \`\`\`bash
+          pip install semaphore-mcp==${VERSION}
+          \`\`\`
+          [View on PyPI](https://pypi.org/project/semaphore-mcp/${VERSION}/)
+
+          ### Container Image
+          \`\`\`bash
+          docker pull ghcr.io/cloin/semaphore-mcp:${VERSION}
+          \`\`\`
+          [View on GHCR](https://github.com/cloin/semaphore-mcp/pkgs/container/semaphore-mcp)
+
+          ---
+
+          EOF
+
+          if [ -n "$PREVIOUS_TAG" ]; then
+            echo "**Full Changelog:** https://github.com/${{ github.repository }}/compare/${PREVIOUS_TAG}...v${VERSION}" >> changelog.md
+          else
+            echo "**Full Changelog:** https://github.com/${{ github.repository }}/commits/v${VERSION}" >> changelog.md
+          fi
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ inputs.version }}
+          name: Release v${{ inputs.version }}
+          body_path: changelog.md
+          prerelease: ${{ inputs.prerelease }}


### PR DESCRIPTION
  Changes Made

  .github/workflows/release-and-publish.yml

  - New workflow structure with 6 sequential jobs:
    a. release - Validate version, bump pyproject.toml, create tag
    b. build - Build Python distribution
    c. publish-to-testpypi - Publish to TestPyPI
    d. publish-to-pypi - Publish to PyPI
    e. build-container - Build and push container to GHCR (runs after PyPI)
    f. create-release - Generate changelog and create GitHub release (runs last)
  - Conventional commit changelog - Parses commits by type:
    - feat: → Features
    - fix: → Bug Fixes
    - docs: → Documentation
    - chore:, refactor:, test:, ci: → Maintenance
    - BREAKING CHANGE → Breaking Changes
    - Other → Other
  - Release notes include PyPI and container installation instructions with links
  - Version validation extended to support pre-release suffixes (e.g., 1.0.0-beta.1)
  - Replaced actions/create-release@v1 with softprops/action-gh-release@v2

  .github/workflows/container-publish.yml

  - Removed release [published] trigger (prevents duplicate container builds)
  - Renamed to "Publish Container (Manual)" for clarity
  - Kept workflow_dispatch for standalone manual container builds
  - Added required tag input parameter