### PR TITLE
fix: ensure stable releases include full changelog from previous stable version

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -72,8 +72,19 @@ jobs:
 
       - name: Get previous tag
         id: get_previous_tag
+        env:
+          CURRENT_VERSION: ${{ inputs.version }}
         run: |
-          PREVIOUS_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          # Detect if current version is a stable release (no prerelease suffix)
+          if [[ "$CURRENT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Current version is a stable release, finding last stable tag..."
+            # Find the last stable tag (exclude prerelease tags)
+            PREVIOUS_TAG=$(git tag --list --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)
+          else
+            echo "Current version is a prerelease, finding last tag..."
+            # For prereleases, use the most recent tag
+            PREVIOUS_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          fi
           echo "tag=${PREVIOUS_TAG}" >> $GITHUB_OUTPUT
           echo "Previous tag: ${PREVIOUS_TAG:-none}"
 


### PR DESCRIPTION
When releasing a stable version (e.g., 1.0.1), the changelog now includes
all changes since the last stable release (e.g., 1.0.0), including any
beta releases in between.

This fixes an issue where beta releases would cause the stable release
changelog to only show changes since the last beta, missing important
changes that were included in the beta versions.