### PR TITLE
fix: add Docker buildx setup to resolve 'unknown blob' error

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -210,6 +210,9 @@ jobs:
         with:
           ref: ${{ needs.release.outputs.release_tag }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to Container Registry
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
Adds docker/setup-buildx-action step before building the container image. This properly initializes buildx and resolves the 'unknown blob' error that was occurring during container builds.

Fixes: https://github.com/cloin/semaphore-mcp/actions/runs/19750901616/job/56593685698