### PR TITLE
added all missing task params

### DIFF
--- a/src/semaphore_mcp/api.py
+++ b/src/semaphore_mcp/api.py
@@ -395,6 +395,15 @@ class SemaphoreAPIClient:
         project_id: int,
         template_id: int,
         environment: Optional[dict[str, str]] = None,
+        limit: Optional[str] = None,
+        dry_run: Optional[bool] = None,
+        diff: Optional[bool] = None,
+        debug: Optional[bool] = None,
+        playbook: Optional[str] = None,
+        git_branch: Optional[str] = None,
+        message: Optional[str] = None,
+        arguments: Optional[str] = None,
+        inventory_id: Optional[int] = None,
     ) -> dict[str, Any]:
         """
         Run a task using a template.
@@ -403,6 +412,15 @@ class SemaphoreAPIClient:
             project_id: Project ID
             template_id: Template ID
             environment: Optional environment variables for the task
+            limit: Restrict execution to specific hosts/groups (Ansible --limit)
+            dry_run: Run without making changes (Ansible --check)
+            diff: Show differences when changing files (Ansible --diff)
+            debug: Enable verbose debug output
+            playbook: Override playbook file path
+            git_branch: Override git branch to use
+            message: Task description/message
+            arguments: Additional CLI arguments
+            inventory_id: Override inventory to use
 
         Returns:
             Task information
@@ -410,6 +428,24 @@ class SemaphoreAPIClient:
         payload: dict[str, Any] = {"template_id": template_id}
         if environment:
             payload["environment"] = environment
+        if limit:
+            payload["limit"] = limit
+        if dry_run is not None:
+            payload["dry_run"] = dry_run
+        if diff is not None:
+            payload["diff"] = diff
+        if debug is not None:
+            payload["debug"] = debug
+        if playbook:
+            payload["playbook"] = playbook
+        if git_branch:
+            payload["git_branch"] = git_branch
+        if message:
+            payload["message"] = message
+        if arguments:
+            payload["arguments"] = arguments
+        if inventory_id is not None:
+            payload["inventory_id"] = inventory_id
 
         return self._request("POST", f"project/{project_id}/tasks", json=payload)
 

--- a/src/semaphore_mcp/tools/tasks.py
+++ b/src/semaphore_mcp/tools/tasks.py
@@ -206,6 +206,15 @@ class TaskTools(BaseTool):
         template_id: int,
         project_id: Optional[int] = None,
         environment: Optional[dict[str, str]] = None,
+        limit: Optional[str] = None,
+        dry_run: Optional[bool] = None,
+        diff: Optional[bool] = None,
+        debug: Optional[bool] = None,
+        playbook: Optional[str] = None,
+        git_branch: Optional[str] = None,
+        message: Optional[str] = None,
+        arguments: Optional[str] = None,
+        inventory_id: Optional[int] = None,
         follow: bool = False,
     ) -> dict[str, Any]:
         """Run a task from a template with optional 30-second monitoring.
@@ -214,6 +223,15 @@ class TaskTools(BaseTool):
             template_id: ID of the template to run
             project_id: Optional project ID (if not provided, will attempt to determine from template)
             environment: Optional environment variables for the task as dictionary
+            limit: Restrict execution to specific hosts/groups (Ansible --limit)
+            dry_run: Run without making changes (Ansible --check)
+            diff: Show differences when changing files (Ansible --diff)
+            debug: Enable verbose debug output
+            playbook: Override playbook file path
+            git_branch: Override git branch to use
+            message: Task description/message
+            arguments: Additional CLI arguments
+            inventory_id: Override inventory to use
             follow: Enable 30-second monitoring for startup verification (default: False)
 
         Returns:
@@ -225,6 +243,12 @@ class TaskTools(BaseTool):
 
             # Start task with 30-second monitoring and get URLs
             result = await run_task(template_id=5, follow=True)
+
+            # Run with limit to specific hosts
+            result = await run_task(template_id=5, limit="webservers")
+
+            # Dry run with diff to preview changes
+            result = await run_task(template_id=5, dry_run=True, diff=True)
         """
         try:
             # If project_id is not provided, we need to find it
@@ -280,7 +304,18 @@ class TaskTools(BaseTool):
             # Now run the task with the determined project_id
             try:
                 task_result = self.semaphore.run_task(
-                    project_id, template_id, environment=environment
+                    project_id,
+                    template_id,
+                    environment=environment,
+                    limit=limit,
+                    dry_run=dry_run,
+                    diff=diff,
+                    debug=debug,
+                    playbook=playbook,
+                    git_branch=git_branch,
+                    message=message,
+                    arguments=arguments,
+                    inventory_id=inventory_id,
                 )
 
                 # Extract task ID for URL generation

--- a/tests/test_task_tools_coverage.py
+++ b/tests/test_task_tools_coverage.py
@@ -79,7 +79,20 @@ class TestTaskToolsCoverage:
 
         assert result["task"]["id"] == 10
         # Verify it found the project and ran the task
-        task_tools.semaphore.run_task.assert_called_once_with(1, 5, environment=None)
+        task_tools.semaphore.run_task.assert_called_once_with(
+            1,
+            5,
+            environment=None,
+            limit=None,
+            dry_run=None,
+            diff=None,
+            debug=None,
+            playbook=None,
+            git_branch=None,
+            message=None,
+            arguments=None,
+            inventory_id=None,
+        )
 
     @pytest.mark.asyncio
     async def test_run_task_project_lookup_with_dict_response(self, task_tools):
@@ -94,7 +107,20 @@ class TestTaskToolsCoverage:
         result = await task_tools.run_task(5)
 
         assert result["task"]["id"] == 10
-        task_tools.semaphore.run_task.assert_called_once_with(1, 5, environment=None)
+        task_tools.semaphore.run_task.assert_called_once_with(
+            1,
+            5,
+            environment=None,
+            limit=None,
+            dry_run=None,
+            diff=None,
+            debug=None,
+            playbook=None,
+            git_branch=None,
+            message=None,
+            arguments=None,
+            inventory_id=None,
+        )
 
     @pytest.mark.asyncio
     async def test_run_task_template_lookup_with_dict_response(self, task_tools):
@@ -363,7 +389,20 @@ class TestTaskToolsCoverage:
         assert "monitoring" in result
         assert result["monitoring"]["enabled"] is False
         # Verify semaphore client was called
-        task_tools.semaphore.run_task.assert_called_once_with(1, 5, environment=None)
+        task_tools.semaphore.run_task.assert_called_once_with(
+            1,
+            5,
+            environment=None,
+            limit=None,
+            dry_run=None,
+            diff=None,
+            debug=None,
+            playbook=None,
+            git_branch=None,
+            message=None,
+            arguments=None,
+            inventory_id=None,
+        )
 
     @pytest.mark.asyncio
     async def test_run_task_no_task_id(self, task_tools):

--- a/tests/tools/test_tasks.py
+++ b/tests/tools/test_tasks.py
@@ -178,7 +178,18 @@ class TestTaskTools:
         assert "project_tasks" in result["web_urls"]
         assert f"#{mock_result['id']}" in result["message"]
         task_tools.semaphore.run_task.assert_called_once_with(
-            project_id, template_id, environment=environment
+            project_id,
+            template_id,
+            environment=environment,
+            limit=None,
+            dry_run=None,
+            diff=None,
+            debug=None,
+            playbook=None,
+            git_branch=None,
+            message=None,
+            arguments=None,
+            inventory_id=None,
         )
 
     @pytest.mark.asyncio
@@ -210,7 +221,18 @@ class TestTaskTools:
         task_tools.semaphore.list_projects.assert_called_once()
         task_tools.semaphore.list_templates.assert_called_once_with(project_id)
         task_tools.semaphore.run_task.assert_called_once_with(
-            project_id, template_id, environment=None
+            project_id,
+            template_id,
+            environment=None,
+            limit=None,
+            dry_run=None,
+            diff=None,
+            debug=None,
+            playbook=None,
+            git_branch=None,
+            message=None,
+            arguments=None,
+            inventory_id=None,
         )
 
     @pytest.mark.asyncio
@@ -374,7 +396,18 @@ class TestTaskTools:
 
         # Verify semaphore client was called
         task_tools.semaphore.run_task.assert_called_once_with(
-            project_id, template_id, environment=environment
+            project_id,
+            template_id,
+            environment=environment,
+            limit=None,
+            dry_run=None,
+            diff=None,
+            debug=None,
+            playbook=None,
+            git_branch=None,
+            message=None,
+            arguments=None,
+            inventory_id=None,
         )
 
         # Check the result structure for immediate URL response
@@ -432,7 +465,18 @@ class TestTaskTools:
 
         # Verify semaphore client and _monitor_task_startup were called
         task_tools.semaphore.run_task.assert_called_once_with(
-            project_id, template_id, environment=environment
+            project_id,
+            template_id,
+            environment=environment,
+            limit=None,
+            dry_run=None,
+            diff=None,
+            debug=None,
+            playbook=None,
+            git_branch=None,
+            message=None,
+            arguments=None,
+            inventory_id=None,
         )
         task_tools._monitor_task_startup.assert_called_once_with(project_id, task_id)
 


### PR DESCRIPTION
Add remaining params for run_task tool:

- limit: Restrict execution to specific hosts/groups (Ansible --limit)
- dry_run: Run without making changes (Ansible --check)
- diff: Show differences when changing files (Ansible --diff)
- debug: Enable verbose debug output
- playbook: Override playbook file path
- git_branch: Override git branch to use
- message: Task description/message
- arguments: Additional CLI arguments
- inventory_id: Override inventory to use