### PR TITLE
add schedule tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ Once connected, you can interact with SemaphoreUI through natural conversation:
 
 **Templates:** `list_templates`, `get_template`, `create_template`, `update_template`, `delete_template`
 
+**Schedules:** `list_schedules`, `list_template_schedules`, `get_schedule`, `create_schedule`, `update_schedule`, `set_schedule_active`, `delete_schedule`, `validate_schedule_cron_format`
+
 **Tasks:** `list_tasks`, `get_task`, `run_task`, `stop_task`, `get_task_raw_output`, `filter_tasks`, `bulk_stop_tasks`
 
 **Analysis:** `analyze_task_failure`, `bulk_analyze_failures`, `get_latest_failed_task`

--- a/src/semaphore_mcp/api.py
+++ b/src/semaphore_mcp/api.py
@@ -71,6 +71,13 @@ class SemaphoreAPIClient:
                     f"The requested resource may have been deleted or the ID may be incorrect.",
                     response=response,
                 ) from e
+            response_body = response.text.strip()
+            if response_body:
+                raise requests.exceptions.HTTPError(
+                    f"{method} {url} failed with {response.status_code}: "
+                    f"{response_body[:500]}",
+                    response=response,
+                ) from e
             raise
 
         if response.content:
@@ -439,6 +446,173 @@ class SemaphoreAPIClient:
         """
         return self._request(
             "POST", f"project/{project_id}/templates/{template_id}/stop_all_tasks"
+        )
+
+    # Schedule endpoints
+    def list_schedules(self, project_id: int) -> list[dict[str, Any]]:
+        """List all schedules for a project."""
+        result = self._request("GET", f"project/{project_id}/schedules")
+        return result if isinstance(result, list) else []
+
+    def list_template_schedules(
+        self, project_id: int, template_id: int
+    ) -> list[dict[str, Any]]:
+        """List schedules attached to a template."""
+        result = self._request(
+            "GET", f"project/{project_id}/templates/{template_id}/schedules"
+        )
+        return result if isinstance(result, list) else []
+
+    def get_schedule(self, project_id: int, schedule_id: int) -> dict[str, Any]:
+        """Get a schedule by ID."""
+        return self._request("GET", f"project/{project_id}/schedules/{schedule_id}")
+
+    def create_schedule(
+        self,
+        project_id: int,
+        template_id: int,
+        name: str,
+        cron_format: Optional[str] = None,
+        active: bool = True,
+        schedule_type: str = "",
+        run_at: Optional[str] = None,
+        task_params: Optional[dict[str, Any]] = None,
+        delete_after_run: Optional[bool] = None,
+        repository_id: Optional[int] = None,
+    ) -> dict[str, Any]:
+        """Create a schedule for a project.
+
+        Args:
+            project_id: Project ID
+            template_id: Template ID to run
+            name: Schedule name
+            cron_format: Cron expression for recurring schedules
+            active: Whether the schedule is enabled
+            schedule_type: Schedule type, either "" for cron or "run_at"
+            run_at: RFC3339 timestamp for one-time schedules
+            task_params: Optional task parameters to pass when the schedule runs
+            delete_after_run: Delete one-time schedule after it runs
+            repository_id: Optional repository ID for commit-check schedules
+
+        Returns:
+            Created schedule information
+        """
+        payload: dict[str, Any] = {
+            "project_id": project_id,
+            "template_id": template_id,
+            "name": name,
+            "active": active,
+            "type": schedule_type,
+        }
+
+        if cron_format is not None:
+            payload["cron_format"] = cron_format
+        if run_at is not None:
+            payload["run_at"] = run_at
+        if task_params is not None:
+            payload["task_params"] = task_params
+        if delete_after_run is not None:
+            payload["delete_after_run"] = delete_after_run
+        if repository_id is not None:
+            payload["repository_id"] = repository_id
+
+        return self._request("POST", f"project/{project_id}/schedules", json=payload)
+
+    def update_schedule(
+        self,
+        project_id: int,
+        schedule_id: int,
+        template_id: Optional[int] = None,
+        name: Optional[str] = None,
+        cron_format: Optional[str] = None,
+        active: Optional[bool] = None,
+        schedule_type: Optional[str] = None,
+        run_at: Optional[str] = None,
+        task_params: Optional[dict[str, Any]] = None,
+        delete_after_run: Optional[bool] = None,
+        repository_id: Optional[int] = None,
+    ) -> dict[str, Any]:
+        """Update an existing schedule.
+
+        Args:
+            project_id: Project ID
+            schedule_id: Schedule ID
+            template_id: Template ID to run
+            name: Schedule name
+            cron_format: Cron expression for recurring schedules
+            active: Whether the schedule is enabled
+            schedule_type: Schedule type, either "" for cron or "run_at"
+            run_at: RFC3339 timestamp for one-time schedules
+            task_params: Optional task parameters to pass when the schedule runs
+            delete_after_run: Delete one-time schedule after it runs
+            repository_id: Optional repository ID for commit-check schedules
+
+        Returns:
+            Empty dict on success
+        """
+        existing = self.get_schedule(project_id, schedule_id)
+        payload: dict[str, Any] = {
+            "id": schedule_id,
+            "project_id": project_id,
+            "template_id": existing.get("template_id", 0),
+            "name": existing.get("name", ""),
+            "cron_format": existing.get("cron_format", ""),
+            "active": existing.get("active", False),
+            "type": existing.get("type", ""),
+            "run_at": existing.get("run_at"),
+            "delete_after_run": existing.get("delete_after_run", False),
+        }
+
+        if existing.get("task_params") is not None:
+            payload["task_params"] = existing["task_params"]
+        if "repository_id" in existing:
+            payload["repository_id"] = existing.get("repository_id")
+
+        if template_id is not None:
+            payload["template_id"] = template_id
+        if name is not None:
+            payload["name"] = name
+        if cron_format is not None:
+            payload["cron_format"] = cron_format
+        if active is not None:
+            payload["active"] = active
+        if schedule_type is not None:
+            payload["type"] = schedule_type
+        if run_at is not None:
+            payload["run_at"] = run_at
+        if task_params is not None:
+            payload["task_params"] = task_params
+        if delete_after_run is not None:
+            payload["delete_after_run"] = delete_after_run
+        if repository_id is not None:
+            payload["repository_id"] = repository_id
+
+        return self._request(
+            "PUT", f"project/{project_id}/schedules/{schedule_id}", json=payload
+        )
+
+    def set_schedule_active(
+        self, project_id: int, schedule_id: int, active: bool
+    ) -> dict[str, Any]:
+        """Enable or disable a schedule."""
+        return self._request(
+            "PUT",
+            f"project/{project_id}/schedules/{schedule_id}/active",
+            json={"active": active},
+        )
+
+    def delete_schedule(self, project_id: int, schedule_id: int) -> dict[str, Any]:
+        """Delete a schedule by ID."""
+        return self._request("DELETE", f"project/{project_id}/schedules/{schedule_id}")
+
+    def validate_schedule_cron_format(
+        self, project_id: int, cron_format: str
+    ) -> dict[str, Any]:
+        """Validate a schedule cron expression."""
+        return self._request(
+            "POST",
+            f"project/{project_id}/schedules/validate",
+            json={"cron_format": cron_format},
         )
 
     # Task endpoints

--- a/src/semaphore_mcp/server.py
+++ b/src/semaphore_mcp/server.py
@@ -16,6 +16,7 @@ from .tools.access_keys import AccessKeyTools
 from .tools.environments import EnvironmentTools
 from .tools.projects import ProjectTools
 from .tools.repositories import RepositoryTools
+from .tools.schedules import ScheduleTools
 from .tools.tasks import TaskTools
 from .tools.templates import TemplateTools
 
@@ -58,6 +59,7 @@ class SemaphoreMCPServer:
         self.environment_tools = EnvironmentTools(self.semaphore)
         self.repository_tools = RepositoryTools(self.semaphore)
         self.access_key_tools = AccessKeyTools(self.semaphore)
+        self.schedule_tools = ScheduleTools(self.semaphore)
 
         # Register tools
         self.register_tools()
@@ -78,6 +80,16 @@ class SemaphoreMCPServer:
         self.mcp.tool()(self.template_tools.update_template)
         self.mcp.tool()(self.template_tools.delete_template)
         self.mcp.tool()(self.template_tools.stop_all_template_tasks)
+
+        # Schedule tools
+        self.mcp.tool()(self.schedule_tools.list_schedules)
+        self.mcp.tool()(self.schedule_tools.list_template_schedules)
+        self.mcp.tool()(self.schedule_tools.get_schedule)
+        self.mcp.tool()(self.schedule_tools.create_schedule)
+        self.mcp.tool()(self.schedule_tools.update_schedule)
+        self.mcp.tool()(self.schedule_tools.set_schedule_active)
+        self.mcp.tool()(self.schedule_tools.delete_schedule)
+        self.mcp.tool()(self.schedule_tools.validate_schedule_cron_format)
 
         # Task tools
         self.mcp.tool()(self.task_tools.list_tasks)

--- a/src/semaphore_mcp/tools/__init__.py
+++ b/src/semaphore_mcp/tools/__init__.py
@@ -8,6 +8,7 @@ from .access_keys import AccessKeyTools
 from .environments import EnvironmentTools
 from .projects import ProjectTools
 from .repositories import RepositoryTools
+from .schedules import ScheduleTools
 from .tasks import TaskTools
 from .templates import TemplateTools
 
@@ -18,4 +19,5 @@ __all__ = [
     "TaskTools",
     "EnvironmentTools",
     "RepositoryTools",
+    "ScheduleTools",
 ]

--- a/src/semaphore_mcp/tools/schedules.py
+++ b/src/semaphore_mcp/tools/schedules.py
@@ -1,0 +1,225 @@
+"""Schedule tools for Semaphore MCP.
+
+Provides tools for managing SemaphoreUI project schedules, including recurring
+cron schedules and one-time run_at schedules.
+"""
+
+from typing import Any, Optional
+
+from .base import BaseTool
+
+
+class ScheduleTools(BaseTool):
+    """Tools for managing Semaphore schedules."""
+
+    def _validate_schedule_inputs(
+        self,
+        cron_format: Optional[str],
+        schedule_type: str,
+        run_at: Optional[str],
+    ) -> None:
+        if schedule_type not in ("", "run_at"):
+            raise ValueError("schedule_type must be '' for cron or 'run_at'")
+        if schedule_type == "run_at" and not run_at:
+            raise ValueError("run_at is required for run_at schedules")
+        if schedule_type == "" and not cron_format:
+            raise ValueError("cron_format is required for cron schedules")
+
+    async def list_schedules(self, project_id: int) -> dict[str, Any]:
+        """List all schedules for a project.
+
+        Args:
+            project_id: ID of the project
+
+        Returns:
+            Dictionary containing list of schedules
+        """
+        try:
+            schedules = self.semaphore.list_schedules(project_id)
+            return {"schedules": schedules}
+        except Exception as e:
+            self.handle_error(e, f"listing schedules for project {project_id}")
+
+    async def list_template_schedules(
+        self, project_id: int, template_id: int
+    ) -> dict[str, Any]:
+        """List schedules attached to a template.
+
+        Args:
+            project_id: ID of the project
+            template_id: ID of the template
+
+        Returns:
+            Dictionary containing list of template schedules
+        """
+        try:
+            schedules = self.semaphore.list_template_schedules(project_id, template_id)
+            return {"schedules": schedules}
+        except Exception as e:
+            self.handle_error(e, f"listing schedules for template {template_id}")
+
+    async def get_schedule(self, project_id: int, schedule_id: int) -> dict[str, Any]:
+        """Get details of a specific schedule.
+
+        Args:
+            project_id: ID of the project
+            schedule_id: ID of the schedule to fetch
+
+        Returns:
+            Schedule details
+        """
+        try:
+            return self.semaphore.get_schedule(project_id, schedule_id)
+        except Exception as e:
+            self.handle_error(e, f"getting schedule {schedule_id}")
+
+    async def create_schedule(
+        self,
+        project_id: int,
+        template_id: int,
+        name: str,
+        cron_format: Optional[str] = None,
+        active: bool = True,
+        schedule_type: str = "",
+        run_at: Optional[str] = None,
+        task_params: Optional[dict[str, Any]] = None,
+        delete_after_run: Optional[bool] = None,
+        repository_id: Optional[int] = None,
+    ) -> dict[str, Any]:
+        """Create a new schedule.
+
+        Args:
+            project_id: ID of the project
+            template_id: ID of the template to run
+            name: Schedule name
+            cron_format: Cron expression for recurring schedules
+            active: Whether the schedule is enabled
+            schedule_type: Schedule type: "" for cron, or "run_at" for one-time runs
+            run_at: RFC3339 timestamp for one-time schedules
+            task_params: Optional task parameters to pass when the schedule runs
+            delete_after_run: Delete the one-time schedule after it runs
+            repository_id: Optional repository ID for commit-check schedules
+
+        Returns:
+            Created schedule details
+        """
+        try:
+            self._validate_schedule_inputs(cron_format, schedule_type, run_at)
+            return self.semaphore.create_schedule(
+                project_id,
+                template_id,
+                name,
+                cron_format,
+                active,
+                schedule_type,
+                run_at,
+                task_params,
+                delete_after_run,
+                repository_id,
+            )
+        except Exception as e:
+            self.handle_error(e, f"creating schedule '{name}' in project {project_id}")
+
+    async def update_schedule(
+        self,
+        project_id: int,
+        schedule_id: int,
+        template_id: Optional[int] = None,
+        name: Optional[str] = None,
+        cron_format: Optional[str] = None,
+        active: Optional[bool] = None,
+        schedule_type: Optional[str] = None,
+        run_at: Optional[str] = None,
+        task_params: Optional[dict[str, Any]] = None,
+        delete_after_run: Optional[bool] = None,
+        repository_id: Optional[int] = None,
+    ) -> dict[str, Any]:
+        """Update an existing schedule.
+
+        Args:
+            project_id: ID of the project
+            schedule_id: ID of the schedule to update
+            template_id: ID of the template to run
+            name: Schedule name
+            cron_format: Cron expression for recurring schedules
+            active: Whether the schedule is enabled
+            schedule_type: Schedule type: "" for cron, or "run_at" for one-time runs
+            run_at: RFC3339 timestamp for one-time schedules
+            task_params: Optional task parameters to pass when the schedule runs
+            delete_after_run: Delete the one-time schedule after it runs
+            repository_id: Optional repository ID for commit-check schedules
+
+        Returns:
+            Updated schedule details or empty dict on success
+        """
+        try:
+            if schedule_type is not None:
+                if schedule_type not in ("", "run_at"):
+                    raise ValueError("schedule_type must be '' for cron or 'run_at'")
+            return self.semaphore.update_schedule(
+                project_id,
+                schedule_id,
+                template_id,
+                name,
+                cron_format,
+                active,
+                schedule_type,
+                run_at,
+                task_params,
+                delete_after_run,
+                repository_id,
+            )
+        except Exception as e:
+            self.handle_error(e, f"updating schedule {schedule_id}")
+
+    async def set_schedule_active(
+        self, project_id: int, schedule_id: int, active: bool
+    ) -> dict[str, Any]:
+        """Enable or disable a schedule.
+
+        Args:
+            project_id: ID of the project
+            schedule_id: ID of the schedule to update
+            active: Whether the schedule should be active
+
+        Returns:
+            Empty dict on success
+        """
+        try:
+            return self.semaphore.set_schedule_active(project_id, schedule_id, active)
+        except Exception as e:
+            self.handle_error(e, f"setting schedule {schedule_id} active={active}")
+
+    async def delete_schedule(
+        self, project_id: int, schedule_id: int
+    ) -> dict[str, Any]:
+        """Delete a schedule.
+
+        Args:
+            project_id: ID of the project
+            schedule_id: ID of the schedule to delete
+
+        Returns:
+            Empty dict on success
+        """
+        try:
+            return self.semaphore.delete_schedule(project_id, schedule_id)
+        except Exception as e:
+            self.handle_error(e, f"deleting schedule {schedule_id}")
+
+    async def validate_schedule_cron_format(
+        self, project_id: int, cron_format: str
+    ) -> dict[str, Any]:
+        """Validate a cron expression for Semaphore schedules.
+
+        Args:
+            project_id: ID of the project
+            cron_format: Cron expression to validate
+
+        Returns:
+            Empty dict on success
+        """
+        try:
+            return self.semaphore.validate_schedule_cron_format(project_id, cron_format)
+        except Exception as e:
+            self.handle_error(e, f"validating schedule cron format '{cron_format}'")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ from semaphore_mcp.tools.access_keys import AccessKeyTools
 from semaphore_mcp.tools.environments import EnvironmentTools
 from semaphore_mcp.tools.projects import ProjectTools
 from semaphore_mcp.tools.repositories import RepositoryTools
+from semaphore_mcp.tools.schedules import ScheduleTools
 from semaphore_mcp.tools.tasks import TaskTools
 from semaphore_mcp.tools.templates import TemplateTools
 
@@ -67,6 +68,12 @@ async def repository_tools(mock_semaphore_client):
 async def access_key_tools(mock_semaphore_client):
     """Create an AccessKeyTools instance with a mock API client."""
     return AccessKeyTools(mock_semaphore_client)
+
+
+@pytest_asyncio.fixture
+async def schedule_tools(mock_semaphore_client):
+    """Create a ScheduleTools instance with a mock API client."""
+    return ScheduleTools(mock_semaphore_client)
 
 
 # =============================================================================
@@ -219,5 +226,34 @@ def sample_access_keys():
             "name": "Login Key",
             "project_id": 1,
             "type": "login_password",
+        },
+    ]
+
+
+@pytest.fixture
+def sample_schedules():
+    """Standard schedule list for testing."""
+    return [
+        {
+            "id": 1,
+            "project_id": 1,
+            "template_id": 10,
+            "name": "Nightly deploy",
+            "cron_format": "0 0 * * *",
+            "active": True,
+            "type": "",
+            "tpl_name": "Deploy",
+        },
+        {
+            "id": 2,
+            "project_id": 1,
+            "template_id": 11,
+            "name": "One-time maintenance",
+            "cron_format": "",
+            "active": False,
+            "type": "run_at",
+            "run_at": "2026-05-19T12:00:00Z",
+            "delete_after_run": True,
+            "tpl_name": "Maintenance",
         },
     ]

--- a/tests/e2e/test_schedules_e2e.py
+++ b/tests/e2e/test_schedules_e2e.py
@@ -1,0 +1,176 @@
+"""E2E tests for schedule tools."""
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+# Add e2e directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent))
+
+from helpers import parse_mcp_response  # noqa: E402
+from mcp_inspector import MCPInspector  # noqa: E402
+
+
+def future_run_at() -> str:
+    """Return an RFC3339 UTC timestamp safely in the future."""
+    return (
+        (datetime.now(timezone.utc) + timedelta(days=1))
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+class TestSchedulesE2E:
+    """E2E tests for schedule CRUD operations."""
+
+    def test_list_schedules(self, inspector: MCPInspector, created_project: dict):
+        """Test listing schedules for a project."""
+        project_id = created_project["id"]
+
+        result = inspector.call_tool("list_schedules", {"project_id": project_id})
+        data = parse_mcp_response(result)
+
+        assert "schedules" in data
+        assert isinstance(data["schedules"], list)
+
+    def test_validate_schedule_cron_format(
+        self, inspector: MCPInspector, created_project: dict
+    ):
+        """Test validating a cron schedule expression."""
+        project_id = created_project["id"]
+
+        result = inspector.call_tool(
+            "validate_schedule_cron_format",
+            {"project_id": project_id, "cron_format": "0 0 * * *"},
+        )
+
+        assert result is not None
+
+    def test_cron_schedule_crud_workflow(
+        self, inspector: MCPInspector, created_template: tuple
+    ):
+        """Test creating, reading, updating, listing, disabling, and deleting a cron schedule."""
+        template, project_id = created_template
+
+        create_result = inspector.call_tool(
+            "create_schedule",
+            {
+                "project_id": project_id,
+                "template_id": template["id"],
+                "name": "E2E Cron Schedule",
+                "cron_format": "0 0 1 1 *",
+                "active": False,
+                "task_params": {"message": "scheduled e2e run"},
+            },
+        )
+        schedule = parse_mcp_response(create_result)
+        assert isinstance(schedule, dict), schedule
+        schedule_id = schedule["id"]
+
+        try:
+            assert schedule["name"] == "E2E Cron Schedule"
+            assert schedule["template_id"] == template["id"]
+            assert schedule["cron_format"] == "0 0 1 1 *"
+            assert schedule["active"] is False
+
+            get_result = inspector.call_tool(
+                "get_schedule",
+                {"project_id": project_id, "schedule_id": schedule_id},
+            )
+            read_schedule = parse_mcp_response(get_result)
+            assert read_schedule["id"] == schedule_id
+
+            inspector.call_tool(
+                "update_schedule",
+                {
+                    "project_id": project_id,
+                    "schedule_id": schedule_id,
+                    "name": "E2E Updated Cron Schedule",
+                    "cron_format": "30 2 1 1 *",
+                },
+            )
+
+            get_result = inspector.call_tool(
+                "get_schedule",
+                {"project_id": project_id, "schedule_id": schedule_id},
+            )
+            updated = parse_mcp_response(get_result)
+            assert updated["name"] == "E2E Updated Cron Schedule"
+            assert updated["cron_format"] == "30 2 1 1 *"
+
+            list_result = inspector.call_tool(
+                "list_schedules", {"project_id": project_id}
+            )
+            schedules = parse_mcp_response(list_result)["schedules"]
+            assert schedule_id in [item["id"] for item in schedules]
+
+            template_schedules_result = inspector.call_tool(
+                "list_template_schedules",
+                {"project_id": project_id, "template_id": template["id"]},
+            )
+            template_schedules = parse_mcp_response(template_schedules_result)[
+                "schedules"
+            ]
+            assert isinstance(template_schedules, list)
+
+            toggle_result = inspector.call_tool(
+                "set_schedule_active",
+                {
+                    "project_id": project_id,
+                    "schedule_id": schedule_id,
+                    "active": False,
+                },
+            )
+            assert toggle_result is not None
+
+        finally:
+            inspector.call_tool(
+                "delete_schedule",
+                {"project_id": project_id, "schedule_id": schedule_id},
+            )
+
+    @pytest.mark.skip(
+        reason=(
+            "semaphoreui/semaphore:latest still validates run_at schedules as cron "
+            "schedules and returns 'Cron: empty spec string'"
+        )
+    )
+    def test_run_at_schedule_create_and_delete(
+        self, inspector: MCPInspector, created_template: tuple
+    ):
+        """Test creating and deleting a one-time run_at schedule."""
+        template, project_id = created_template
+
+        create_result = inspector.call_tool(
+            "create_schedule",
+            {
+                "project_id": project_id,
+                "template_id": template["id"],
+                "name": "E2E Run Once Schedule",
+                "active": False,
+                "schedule_type": "run_at",
+                "run_at": future_run_at(),
+                "delete_after_run": True,
+            },
+        )
+        schedule = parse_mcp_response(create_result)
+        assert isinstance(schedule, dict), schedule
+        schedule_id = schedule["id"]
+
+        try:
+            assert schedule["name"] == "E2E Run Once Schedule"
+            assert schedule["type"] == "run_at"
+            assert schedule["active"] is False
+            assert "run_at" in schedule
+        finally:
+            inspector.call_tool(
+                "delete_schedule",
+                {"project_id": project_id, "schedule_id": schedule_id},
+            )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/e2e/test_task_execution_e2e.py
+++ b/tests/e2e/test_task_execution_e2e.py
@@ -384,13 +384,13 @@ class TestTaskExecutionE2E:
         """Test getting raw output from a completed task."""
         template, project_id = task_test_template
 
-        # Run a task and wait for completion
+        # Start the task, then poll for completion to avoid holding the Inspector
+        # request open long enough to hit its internal MCP request timeout.
         run_result = inspector.call_tool(
             "run_task",
             {
                 "template_id": template["id"],
                 "project_id": project_id,
-                "follow": True,
             },
         )
         run_data = parse_mcp_response(run_result)

--- a/tests/e2e/test_tool_registration.py
+++ b/tests/e2e/test_tool_registration.py
@@ -24,6 +24,15 @@ EXPECTED_TOOLS = {
     "update_template",
     "delete_template",
     "stop_all_template_tasks",
+    # Schedule tools (8)
+    "list_schedules",
+    "list_template_schedules",
+    "get_schedule",
+    "create_schedule",
+    "update_schedule",
+    "set_schedule_active",
+    "delete_schedule",
+    "validate_schedule_cron_format",
     # Task tools (11) - restart_task and bulk_restart_tasks are commented out in tasks.py
     "list_tasks",
     "get_task",

--- a/tests/test_api_comprehensive.py
+++ b/tests/test_api_comprehensive.py
@@ -208,6 +208,163 @@ class TestSemaphoreAPIClientComprehensive:
             result = mock_client.restart_task(1, 1)
             assert result == mock_response
 
+    def test_list_schedules_dict_response(self, mock_client):
+        """Test list_schedules when API returns dict instead of list."""
+        mock_response = {"schedules": [{"id": 1, "name": "nightly"}]}
+        with patch.object(mock_client, "_request", return_value=mock_response):
+            result = mock_client.list_schedules(1)
+            assert result == []
+
+    def test_list_schedules_list_response(self, mock_client):
+        """Test list_schedules when API returns list."""
+        mock_response = [{"id": 1, "name": "nightly"}]
+        with patch.object(mock_client, "_request", return_value=mock_response):
+            result = mock_client.list_schedules(1)
+            assert result == mock_response
+
+    def test_list_template_schedules(self, mock_client):
+        """Test list_template_schedules method."""
+        mock_response = [{"id": 1, "template_id": 2}]
+        with patch.object(
+            mock_client, "_request", return_value=mock_response
+        ) as mock_request:
+            result = mock_client.list_template_schedules(1, 2)
+            assert result == mock_response
+            mock_request.assert_called_once_with(
+                "GET", "project/1/templates/2/schedules"
+            )
+
+    def test_get_schedule(self, mock_client):
+        """Test get_schedule method."""
+        mock_response = {"id": 1, "name": "nightly"}
+        with patch.object(
+            mock_client, "_request", return_value=mock_response
+        ) as mock_request:
+            result = mock_client.get_schedule(1, 1)
+            assert result == mock_response
+            mock_request.assert_called_once_with("GET", "project/1/schedules/1")
+
+    def test_create_cron_schedule(self, mock_client):
+        """Test create_schedule method for cron schedules."""
+        mock_response = {"id": 1, "name": "nightly"}
+        with patch.object(
+            mock_client, "_request", return_value=mock_response
+        ) as mock_request:
+            result = mock_client.create_schedule(
+                1,
+                2,
+                "nightly",
+                cron_format="0 0 * * *",
+                active=False,
+                task_params={"message": "scheduled"},
+            )
+            assert result == mock_response
+            mock_request.assert_called_once_with(
+                "POST",
+                "project/1/schedules",
+                json={
+                    "project_id": 1,
+                    "template_id": 2,
+                    "name": "nightly",
+                    "active": False,
+                    "type": "",
+                    "cron_format": "0 0 * * *",
+                    "task_params": {"message": "scheduled"},
+                },
+            )
+
+    def test_create_run_at_schedule(self, mock_client):
+        """Test create_schedule method for one-time schedules."""
+        mock_response = {"id": 1, "type": "run_at"}
+        with patch.object(
+            mock_client, "_request", return_value=mock_response
+        ) as mock_request:
+            result = mock_client.create_schedule(
+                1,
+                2,
+                "maintenance",
+                active=False,
+                schedule_type="run_at",
+                run_at="2026-05-19T12:00:00Z",
+                delete_after_run=True,
+            )
+            assert result == mock_response
+            mock_request.assert_called_once_with(
+                "POST",
+                "project/1/schedules",
+                json={
+                    "project_id": 1,
+                    "template_id": 2,
+                    "name": "maintenance",
+                    "active": False,
+                    "type": "run_at",
+                    "run_at": "2026-05-19T12:00:00Z",
+                    "delete_after_run": True,
+                },
+            )
+
+    def test_update_schedule_preserves_existing_fields(self, mock_client):
+        """Test update_schedule fetches existing schedule and preserves fields."""
+        existing = {
+            "id": 3,
+            "project_id": 1,
+            "template_id": 2,
+            "name": "nightly",
+            "cron_format": "0 0 * * *",
+            "active": False,
+            "type": "",
+            "delete_after_run": False,
+        }
+        with patch.object(
+            mock_client, "_request", side_effect=[existing, {}]
+        ) as mock_request:
+            result = mock_client.update_schedule(1, 3, name="updated", active=True)
+            assert result == {}
+            assert mock_request.call_count == 2
+            mock_request.assert_any_call("GET", "project/1/schedules/3")
+            mock_request.assert_any_call(
+                "PUT",
+                "project/1/schedules/3",
+                json={
+                    "id": 3,
+                    "project_id": 1,
+                    "template_id": 2,
+                    "name": "updated",
+                    "cron_format": "0 0 * * *",
+                    "active": True,
+                    "type": "",
+                    "run_at": None,
+                    "delete_after_run": False,
+                },
+            )
+
+    def test_set_schedule_active(self, mock_client):
+        """Test set_schedule_active method."""
+        with patch.object(mock_client, "_request", return_value={}) as mock_request:
+            result = mock_client.set_schedule_active(1, 3, False)
+            assert result == {}
+            mock_request.assert_called_once_with(
+                "PUT", "project/1/schedules/3/active", json={"active": False}
+            )
+
+    def test_delete_schedule(self, mock_client):
+        """Test delete_schedule method."""
+        with patch.object(mock_client, "_request", return_value={}) as mock_request:
+            result = mock_client.delete_schedule(1, 3)
+            assert result == {}
+            mock_request.assert_called_once_with("DELETE", "project/1/schedules/3")
+
+    def test_validate_schedule_cron_format(self, mock_client):
+        """Test validate_schedule_cron_format method."""
+        with patch.object(mock_client, "_request", return_value={}) as mock_request:
+            result = mock_client.validate_schedule_cron_format(1, "0 0 * * *")
+            assert result == {}
+            mock_request.assert_called_once_with(
+                "POST",
+                "project/1/schedules/validate",
+                json={"cron_format": "0 0 * * *"},
+            )
+
     def test_list_environments_dict_response(self, mock_client):
         """Test list_environments when API returns dict instead of list."""
         mock_response = {"environments": [{"id": 1, "name": "test"}]}
@@ -723,6 +880,27 @@ class TestAPIClientErrorHandling:
                 mock_client._request("GET", "project/999")
             assert "Resource not found (404)" in str(exc_info.value)
             assert "may have been deleted" in str(exc_info.value)
+
+    def test_request_http_error_includes_response_body(self, mock_client):
+        """Test that HTTP errors include Semaphore's response body."""
+        import requests
+
+        mock_response = Mock()
+        mock_response.status_code = 400
+        mock_response.content = b'{"error":"Cron: empty spec string"}'
+        mock_response.text = '{"error":"Cron: empty spec string"}'
+        http_error = requests.exceptions.HTTPError(response=mock_response)
+        mock_response.raise_for_status.side_effect = http_error
+
+        with patch.object(mock_client.session, "request", return_value=mock_response):
+            with pytest.raises(requests.exceptions.HTTPError) as exc_info:
+                mock_client._request("POST", "project/1/schedules")
+            assert (
+                "POST http://test.example.com/api/project/1/schedules failed with 400"
+                in str(exc_info.value)
+            )
+            assert "Cron: empty spec string" in str(exc_info.value)
+            assert exc_info.value.response is mock_response
 
     def test_request_invalid_json_response(self, mock_client):
         """Test handling of invalid JSON responses."""

--- a/tests/test_server_coverage.py
+++ b/tests/test_server_coverage.py
@@ -22,6 +22,7 @@ class TestSemaphoreMCPServerCoverage:
         assert server.template_tools is not None
         assert server.task_tools is not None
         assert server.environment_tools is not None
+        assert server.schedule_tools is not None
 
     @patch("semaphore_mcp.server.get_config")
     def test_server_initialization_from_config(self, mock_get_config):
@@ -127,6 +128,7 @@ class TestSemaphoreMCPServerCoverage:
             assert server.template_tools.semaphore == mock_semaphore
             assert server.task_tools.semaphore == mock_semaphore
             assert server.environment_tools.semaphore == mock_semaphore
+            assert server.schedule_tools.semaphore == mock_semaphore
 
     @patch("semaphore_mcp.server.FastMCP")
     def test_fastmcp_initialization(self, mock_fastmcp_class):
@@ -178,6 +180,7 @@ class TestSemaphoreMCPServerCoverage:
             "template_tools",
             "task_tools",
             "environment_tools",
+            "schedule_tools",
         ]
 
         for attr in required_attributes:

--- a/tests/tools/test_schedules.py
+++ b/tests/tools/test_schedules.py
@@ -1,0 +1,208 @@
+"""Tests for ScheduleTools."""
+
+import pytest
+
+
+class TestScheduleTools:
+    """Test suite for schedule tool methods."""
+
+    @pytest.mark.asyncio
+    async def test_list_schedules(self, schedule_tools, sample_schedules):
+        """Test list_schedules method."""
+        project_id = 1
+        schedule_tools.semaphore.list_schedules.return_value = sample_schedules
+
+        result = await schedule_tools.list_schedules(project_id)
+
+        assert result == {"schedules": sample_schedules}
+        schedule_tools.semaphore.list_schedules.assert_called_once_with(project_id)
+
+    @pytest.mark.asyncio
+    async def test_list_template_schedules(self, schedule_tools, sample_schedules):
+        """Test list_template_schedules method."""
+        project_id = 1
+        template_id = 10
+        schedule_tools.semaphore.list_template_schedules.return_value = [
+            sample_schedules[0]
+        ]
+
+        result = await schedule_tools.list_template_schedules(project_id, template_id)
+
+        assert result == {"schedules": [sample_schedules[0]]}
+        schedule_tools.semaphore.list_template_schedules.assert_called_once_with(
+            project_id, template_id
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_schedule(self, schedule_tools, sample_schedules):
+        """Test get_schedule method."""
+        project_id = 1
+        schedule_id = 1
+        schedule_tools.semaphore.get_schedule.return_value = sample_schedules[0]
+
+        result = await schedule_tools.get_schedule(project_id, schedule_id)
+
+        assert result == sample_schedules[0]
+        schedule_tools.semaphore.get_schedule.assert_called_once_with(
+            project_id, schedule_id
+        )
+
+    @pytest.mark.asyncio
+    async def test_create_cron_schedule(self, schedule_tools, sample_schedules):
+        """Test create_schedule method with a cron schedule."""
+        project_id = 1
+        template_id = 10
+        name = "Nightly deploy"
+        cron_format = "0 0 * * *"
+        schedule_tools.semaphore.create_schedule.return_value = sample_schedules[0]
+
+        result = await schedule_tools.create_schedule(
+            project_id,
+            template_id,
+            name,
+            cron_format=cron_format,
+            active=False,
+            task_params={"message": "scheduled run"},
+        )
+
+        assert result == sample_schedules[0]
+        schedule_tools.semaphore.create_schedule.assert_called_once_with(
+            project_id,
+            template_id,
+            name,
+            cron_format,
+            False,
+            "",
+            None,
+            {"message": "scheduled run"},
+            None,
+            None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_create_run_at_schedule(self, schedule_tools, sample_schedules):
+        """Test create_schedule method with a one-time run_at schedule."""
+        project_id = 1
+        template_id = 11
+        name = "One-time maintenance"
+        run_at = "2026-05-19T12:00:00Z"
+        schedule_tools.semaphore.create_schedule.return_value = sample_schedules[1]
+
+        result = await schedule_tools.create_schedule(
+            project_id,
+            template_id,
+            name,
+            active=False,
+            schedule_type="run_at",
+            run_at=run_at,
+            delete_after_run=True,
+        )
+
+        assert result == sample_schedules[1]
+        schedule_tools.semaphore.create_schedule.assert_called_once_with(
+            project_id,
+            template_id,
+            name,
+            None,
+            False,
+            "run_at",
+            run_at,
+            None,
+            True,
+            None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_create_cron_schedule_requires_cron_format(self, schedule_tools):
+        """Test create_schedule validates missing cron_format."""
+        with pytest.raises(RuntimeError) as excinfo:
+            await schedule_tools.create_schedule(1, 10, "Missing cron")
+
+        assert "cron_format is required" in str(excinfo.value)
+        schedule_tools.semaphore.create_schedule.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_create_run_at_schedule_requires_run_at(self, schedule_tools):
+        """Test create_schedule validates missing run_at."""
+        with pytest.raises(RuntimeError) as excinfo:
+            await schedule_tools.create_schedule(
+                1, 10, "Missing run_at", schedule_type="run_at"
+            )
+
+        assert "run_at is required" in str(excinfo.value)
+        schedule_tools.semaphore.create_schedule.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_schedule(self, schedule_tools):
+        """Test update_schedule method."""
+        project_id = 1
+        schedule_id = 2
+        mock_updated = {"id": schedule_id, "name": "Updated"}
+        schedule_tools.semaphore.update_schedule.return_value = mock_updated
+
+        result = await schedule_tools.update_schedule(
+            project_id,
+            schedule_id,
+            name="Updated",
+            active=True,
+            cron_format="30 2 * * *",
+        )
+
+        assert result == mock_updated
+        schedule_tools.semaphore.update_schedule.assert_called_once_with(
+            project_id,
+            schedule_id,
+            None,
+            "Updated",
+            "30 2 * * *",
+            True,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_set_schedule_active(self, schedule_tools):
+        """Test set_schedule_active method."""
+        schedule_tools.semaphore.set_schedule_active.return_value = {}
+
+        result = await schedule_tools.set_schedule_active(1, 2, False)
+
+        assert result == {}
+        schedule_tools.semaphore.set_schedule_active.assert_called_once_with(
+            1, 2, False
+        )
+
+    @pytest.mark.asyncio
+    async def test_delete_schedule(self, schedule_tools):
+        """Test delete_schedule method."""
+        schedule_tools.semaphore.delete_schedule.return_value = {}
+
+        result = await schedule_tools.delete_schedule(1, 2)
+
+        assert result == {}
+        schedule_tools.semaphore.delete_schedule.assert_called_once_with(1, 2)
+
+    @pytest.mark.asyncio
+    async def test_validate_schedule_cron_format(self, schedule_tools):
+        """Test validate_schedule_cron_format method."""
+        schedule_tools.semaphore.validate_schedule_cron_format.return_value = {}
+
+        result = await schedule_tools.validate_schedule_cron_format(1, "0 0 * * *")
+
+        assert result == {}
+        schedule_tools.semaphore.validate_schedule_cron_format.assert_called_once_with(
+            1, "0 0 * * *"
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_schedules_error(self, schedule_tools):
+        """Test list_schedules method with error."""
+        schedule_tools.semaphore.list_schedules.side_effect = Exception("API error")
+
+        with pytest.raises(RuntimeError) as excinfo:
+            await schedule_tools.list_schedules(1)
+
+        assert "Error during listing schedules" in str(excinfo.value)


### PR DESCRIPTION
- Add Semaphore schedule API methods and MCP tools
- Register and document schedule tools
- Add unit/API/server coverage and Docker E2E coverage for cron schedules
- Improve HTTP error messages and reduce E2E Inspector timeout flakiness