### PR TITLE
feat: add semaphore view tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ Once connected, you can interact with SemaphoreUI through natural conversation:
 
 **Projects:** `list_projects`, `get_project`, `create_project`, `update_project`, `delete_project`
 
+**Views:** `list_views`, `get_view`, `create_view`, `update_view`, `delete_view`
+
 **Templates:** `list_templates`, `get_template`, `create_template`, `update_template`, `delete_template`
 
 **Schedules:** `list_schedules`, `list_template_schedules`, `get_schedule`, `create_schedule`, `update_schedule`, `set_schedule_active`, `delete_schedule`, `validate_schedule_cron_format`

--- a/src/semaphore_mcp/api.py
+++ b/src/semaphore_mcp/api.py
@@ -184,6 +184,83 @@ class SemaphoreAPIClient:
         """
         return self._request("DELETE", f"project/{project_id}")
 
+    # View endpoints
+    def list_views(self, project_id: int) -> list[dict[str, Any]]:
+        """List all views for a project."""
+        result = self._request("GET", f"project/{project_id}/views")
+        return result if isinstance(result, list) else []
+
+    def get_view(self, project_id: int, view_id: int) -> dict[str, Any]:
+        """Get a view by ID."""
+        return self._request("GET", f"project/{project_id}/views/{view_id}")
+
+    def create_view(
+        self,
+        project_id: int,
+        title: str,
+        position: Optional[int] = None,
+    ) -> dict[str, Any]:
+        """Create a new view for a project.
+
+        Args:
+            project_id: Project ID
+            title: View title
+            position: View ordering position
+
+        Returns:
+            Created view information
+        """
+        payload: dict[str, Any] = {
+            "project_id": project_id,
+            "title": title,
+        }
+
+        if position is not None:
+            payload["position"] = position
+
+        return self._request("POST", f"project/{project_id}/views", json=payload)
+
+    def update_view(
+        self,
+        project_id: int,
+        view_id: int,
+        title: Optional[str] = None,
+        position: Optional[int] = None,
+    ) -> dict[str, Any]:
+        """Update an existing view.
+
+        Args:
+            project_id: Project ID
+            view_id: View ID
+            title: View title
+            position: View ordering position
+
+        Returns:
+            Empty dict on success
+        """
+        existing = self.get_view(project_id, view_id)
+        payload: dict[str, Any] = {
+            "id": view_id,
+            "project_id": project_id,
+            "title": existing.get("title", ""),
+        }
+
+        if existing.get("position") is not None:
+            payload["position"] = existing["position"]
+
+        if title is not None:
+            payload["title"] = title
+        if position is not None:
+            payload["position"] = position
+
+        return self._request(
+            "PUT", f"project/{project_id}/views/{view_id}", json=payload
+        )
+
+    def delete_view(self, project_id: int, view_id: int) -> dict[str, Any]:
+        """Delete a view by ID."""
+        return self._request("DELETE", f"project/{project_id}/views/{view_id}")
+
     # Template endpoints
     def list_templates(self, project_id: int) -> list[dict[str, Any]]:
         """List all templates for a project."""

--- a/src/semaphore_mcp/server.py
+++ b/src/semaphore_mcp/server.py
@@ -19,6 +19,7 @@ from .tools.repositories import RepositoryTools
 from .tools.schedules import ScheduleTools
 from .tools.tasks import TaskTools
 from .tools.templates import TemplateTools
+from .tools.views import ViewTools
 
 # Configure logging
 configure_logging()
@@ -60,6 +61,7 @@ class SemaphoreMCPServer:
         self.repository_tools = RepositoryTools(self.semaphore)
         self.access_key_tools = AccessKeyTools(self.semaphore)
         self.schedule_tools = ScheduleTools(self.semaphore)
+        self.view_tools = ViewTools(self.semaphore)
 
         # Register tools
         self.register_tools()
@@ -72,6 +74,13 @@ class SemaphoreMCPServer:
         self.mcp.tool()(self.project_tools.create_project)
         self.mcp.tool()(self.project_tools.update_project)
         self.mcp.tool()(self.project_tools.delete_project)
+
+        # View tools
+        self.mcp.tool()(self.view_tools.list_views)
+        self.mcp.tool()(self.view_tools.get_view)
+        self.mcp.tool()(self.view_tools.create_view)
+        self.mcp.tool()(self.view_tools.update_view)
+        self.mcp.tool()(self.view_tools.delete_view)
 
         # Template tools
         self.mcp.tool()(self.template_tools.list_templates)

--- a/src/semaphore_mcp/tools/__init__.py
+++ b/src/semaphore_mcp/tools/__init__.py
@@ -11,6 +11,7 @@ from .repositories import RepositoryTools
 from .schedules import ScheduleTools
 from .tasks import TaskTools
 from .templates import TemplateTools
+from .views import ViewTools
 
 __all__ = [
     "AccessKeyTools",
@@ -20,4 +21,5 @@ __all__ = [
     "EnvironmentTools",
     "RepositoryTools",
     "ScheduleTools",
+    "ViewTools",
 ]

--- a/src/semaphore_mcp/tools/views.py
+++ b/src/semaphore_mcp/tools/views.py
@@ -1,0 +1,105 @@
+"""
+View-related tools for Semaphore MCP.
+
+This module provides tools for managing SemaphoreUI project views.
+"""
+
+import logging
+from typing import Any, Optional
+
+from .base import BaseTool
+
+logger = logging.getLogger(__name__)
+
+
+class ViewTools(BaseTool):
+    """Tools for working with Semaphore project views."""
+
+    async def list_views(self, project_id: int) -> dict[str, Any]:
+        """List all views for a project.
+
+        Args:
+            project_id: ID of the project
+
+        Returns:
+            Dictionary containing the list of views
+        """
+        try:
+            views = self.semaphore.list_views(project_id)
+            return {"views": views}
+        except Exception as e:
+            self.handle_error(e, f"listing views for project {project_id}")
+
+    async def get_view(self, project_id: int, view_id: int) -> dict[str, Any]:
+        """Get details of a specific view.
+
+        Args:
+            project_id: ID of the project
+            view_id: ID of the view to fetch
+
+        Returns:
+            View details
+        """
+        try:
+            return self.semaphore.get_view(project_id, view_id)
+        except Exception as e:
+            self.handle_error(e, f"getting view {view_id}")
+
+    async def create_view(
+        self,
+        project_id: int,
+        title: str,
+        position: Optional[int] = None,
+    ) -> dict[str, Any]:
+        """Create a new view.
+
+        Args:
+            project_id: ID of the project
+            title: View title
+            position: View ordering position
+
+        Returns:
+            Created view details
+        """
+        try:
+            return self.semaphore.create_view(project_id, title, position)
+        except Exception as e:
+            self.handle_error(e, f"creating view '{title}' in project {project_id}")
+
+    async def update_view(
+        self,
+        project_id: int,
+        view_id: int,
+        title: Optional[str] = None,
+        position: Optional[int] = None,
+    ) -> dict[str, Any]:
+        """Update an existing view.
+
+        Args:
+            project_id: ID of the project
+            view_id: ID of the view to update
+            title: View title
+            position: View ordering position
+
+        Returns:
+            Empty dict on success
+        """
+        try:
+            return self.semaphore.update_view(project_id, view_id, title, position)
+        except Exception as e:
+            self.handle_error(e, f"updating view {view_id}")
+
+    async def delete_view(self, project_id: int, view_id: int) -> dict[str, Any]:
+        """Delete a view.
+
+        Args:
+            project_id: ID of the project
+            view_id: ID of the view to delete
+
+        Returns:
+            Empty dict on success
+        """
+        try:
+            return self.semaphore.delete_view(project_id, view_id)
+        except Exception as e:
+            self.handle_error(e, f"deleting view {view_id}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ from semaphore_mcp.tools.repositories import RepositoryTools
 from semaphore_mcp.tools.schedules import ScheduleTools
 from semaphore_mcp.tools.tasks import TaskTools
 from semaphore_mcp.tools.templates import TemplateTools
+from semaphore_mcp.tools.views import ViewTools
 
 # =============================================================================
 # Mock API Client Fixtures
@@ -74,6 +75,12 @@ async def access_key_tools(mock_semaphore_client):
 async def schedule_tools(mock_semaphore_client):
     """Create a ScheduleTools instance with a mock API client."""
     return ScheduleTools(mock_semaphore_client)
+
+
+@pytest_asyncio.fixture
+async def view_tools(mock_semaphore_client):
+    """Create a ViewTools instance with a mock API client."""
+    return ViewTools(mock_semaphore_client)
 
 
 # =============================================================================
@@ -144,6 +151,15 @@ def sample_templates():
     return [
         {"id": 1, "name": "Template 1", "project_id": 1, "playbook": "playbook1.yml"},
         {"id": 2, "name": "Template 2", "project_id": 1, "playbook": "playbook2.yml"},
+    ]
+
+
+@pytest.fixture
+def sample_views():
+    """Standard view list for testing."""
+    return [
+        {"id": 1, "title": "Deployments", "project_id": 1, "position": 1},
+        {"id": 2, "title": "Maintenance", "project_id": 1, "position": 2},
     ]
 
 

--- a/tests/e2e/mcp_inspector.py
+++ b/tests/e2e/mcp_inspector.py
@@ -3,6 +3,7 @@
 import json
 import os
 import subprocess
+import time
 from typing import Any
 
 
@@ -28,6 +29,12 @@ class MCPInspector:
         self.server_url = server_url
         self.transport = transport
         self.timeout = int(os.getenv("MCP_INSPECTOR_TIMEOUT", "90"))
+        self.retries = int(os.getenv("MCP_INSPECTOR_RETRIES", "2"))
+        self.retry_delay = float(os.getenv("MCP_INSPECTOR_RETRY_DELAY", "2"))
+
+    def _is_retryable_error(self, output: str) -> bool:
+        """Return whether Inspector output looks like a transient MCP timeout."""
+        return "MCP error -32001" in output or "Request timed out" in output
 
     def _run_inspector(self, args: list[str]) -> dict[str, Any]:
         """Run MCP Inspector CLI and return parsed JSON output.
@@ -50,26 +57,39 @@ class MCPInspector:
             self.transport,
         ] + args
 
-        try:
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                check=True,
-                timeout=self.timeout,
-            )
-            # Parse JSON from stdout
-            return json.loads(result.stdout)
-        except subprocess.CalledProcessError as e:
-            raise MCPInspectorError(
-                f"Inspector command failed: {e.stderr or e.stdout}"
-            ) from e
-        except json.JSONDecodeError as e:
-            raise MCPInspectorError(
-                f"Failed to parse inspector output: {result.stdout}"
-            ) from e
-        except subprocess.TimeoutExpired as e:
-            raise MCPInspectorError("Inspector command timed out") from e
+        last_error: Exception | None = None
+        for attempt in range(self.retries + 1):
+            try:
+                result = subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                    timeout=self.timeout,
+                )
+                # Parse JSON from stdout
+                return json.loads(result.stdout)
+            except subprocess.CalledProcessError as e:
+                output = e.stderr or e.stdout or ""
+                if attempt < self.retries and self._is_retryable_error(output):
+                    last_error = e
+                    time.sleep(self.retry_delay)
+                    continue
+                raise MCPInspectorError(f"Inspector command failed: {output}") from e
+            except json.JSONDecodeError as e:
+                raise MCPInspectorError(
+                    f"Failed to parse inspector output: {result.stdout}"
+                ) from e
+            except subprocess.TimeoutExpired as e:
+                if attempt < self.retries:
+                    last_error = e
+                    time.sleep(self.retry_delay)
+                    continue
+                raise MCPInspectorError("Inspector command timed out") from e
+
+        raise MCPInspectorError(
+            "Inspector command failed after retries"
+        ) from last_error
 
     def list_tools(self) -> list[dict[str, Any]]:
         """List all available tools.

--- a/tests/e2e/test_tool_registration.py
+++ b/tests/e2e/test_tool_registration.py
@@ -17,6 +17,12 @@ EXPECTED_TOOLS = {
     "create_project",
     "update_project",
     "delete_project",
+    # View tools (5)
+    "list_views",
+    "get_view",
+    "create_view",
+    "update_view",
+    "delete_view",
     # Template tools (6)
     "list_templates",
     "get_template",

--- a/tests/e2e/test_views_e2e.py
+++ b/tests/e2e/test_views_e2e.py
@@ -1,0 +1,78 @@
+"""E2E tests for View tools."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add e2e directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent))
+
+from helpers import parse_mcp_response  # noqa: E402
+from mcp_inspector import MCPInspector  # noqa: E402
+
+
+class TestViewsE2E:
+    """E2E tests for view CRUD operations."""
+
+    def test_list_views(self, inspector: MCPInspector, created_project: dict):
+        """Test listing views for a project."""
+        project_id = created_project["id"]
+
+        result = inspector.call_tool("list_views", {"project_id": project_id})
+        data = parse_mcp_response(result)
+
+        assert "views" in data
+        assert isinstance(data["views"], list)
+
+    def test_view_crud_workflow(self, inspector: MCPInspector, created_project: dict):
+        """Test creating, reading, updating, listing, and deleting a view."""
+        project_id = created_project["id"]
+
+        create_result = inspector.call_tool(
+            "create_view",
+            {"project_id": project_id, "title": "E2E View", "position": 1},
+        )
+        view = parse_mcp_response(create_result)
+        assert isinstance(view, dict), view
+        view_id = view["id"]
+
+        try:
+            assert view["title"] == "E2E View"
+            assert view["project_id"] == project_id
+
+            get_result = inspector.call_tool(
+                "get_view", {"project_id": project_id, "view_id": view_id}
+            )
+            read_view = parse_mcp_response(get_result)
+            assert read_view["id"] == view_id
+
+            inspector.call_tool(
+                "update_view",
+                {
+                    "project_id": project_id,
+                    "view_id": view_id,
+                    "title": "E2E Updated View",
+                    "position": 2,
+                },
+            )
+
+            get_result = inspector.call_tool(
+                "get_view", {"project_id": project_id, "view_id": view_id}
+            )
+            updated = parse_mcp_response(get_result)
+            assert updated["title"] == "E2E Updated View"
+            assert updated["position"] == 2
+
+            list_result = inspector.call_tool("list_views", {"project_id": project_id})
+            views = parse_mcp_response(list_result)["views"]
+            assert view_id in [item["id"] for item in views]
+
+        finally:
+            inspector.call_tool(
+                "delete_view", {"project_id": project_id, "view_id": view_id}
+            )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_api_comprehensive.py
+++ b/tests/test_api_comprehensive.py
@@ -87,6 +87,81 @@ class TestSemaphoreAPIClientComprehensive:
             result = mock_client.get_project(1)
             assert result == mock_response
 
+    def test_list_views_dict_response(self, mock_client):
+        """Test list_views when API returns dict instead of list."""
+        mock_response = {"views": [{"id": 1, "title": "deployments"}]}
+        with patch.object(mock_client, "_request", return_value=mock_response):
+            result = mock_client.list_views(1)
+            assert result == []
+
+    def test_list_views_list_response(self, mock_client):
+        """Test list_views when API returns list."""
+        mock_response = [{"id": 1, "title": "deployments"}]
+        with patch.object(mock_client, "_request", return_value=mock_response):
+            result = mock_client.list_views(1)
+            assert result == mock_response
+
+    def test_get_view(self, mock_client):
+        """Test get_view method."""
+        mock_response = {"id": 1, "title": "deployments"}
+        with patch.object(
+            mock_client, "_request", return_value=mock_response
+        ) as mock_request:
+            result = mock_client.get_view(1, 1)
+            assert result == mock_response
+            mock_request.assert_called_once_with("GET", "project/1/views/1")
+
+    def test_create_view(self, mock_client):
+        """Test create_view method."""
+        mock_response = {"id": 1, "title": "deployments"}
+        with patch.object(
+            mock_client, "_request", return_value=mock_response
+        ) as mock_request:
+            result = mock_client.create_view(1, "deployments", position=2)
+            assert result == mock_response
+            mock_request.assert_called_once_with(
+                "POST",
+                "project/1/views",
+                json={"project_id": 1, "title": "deployments", "position": 2},
+            )
+
+    def test_create_view_without_position(self, mock_client):
+        """Test create_view omits optional position."""
+        mock_response = {"id": 1, "title": "deployments"}
+        with patch.object(
+            mock_client, "_request", return_value=mock_response
+        ) as mock_request:
+            result = mock_client.create_view(1, "deployments")
+            assert result == mock_response
+            mock_request.assert_called_once_with(
+                "POST",
+                "project/1/views",
+                json={"project_id": 1, "title": "deployments"},
+            )
+
+    def test_update_view_preserves_existing_fields(self, mock_client):
+        """Test update_view fetches existing view and preserves fields."""
+        existing = {"id": 3, "project_id": 1, "title": "deployments", "position": 1}
+        with patch.object(
+            mock_client, "_request", side_effect=[existing, {}]
+        ) as mock_request:
+            result = mock_client.update_view(1, 3, title="updated", position=2)
+            assert result == {}
+            assert mock_request.call_count == 2
+            mock_request.assert_any_call("GET", "project/1/views/3")
+            mock_request.assert_any_call(
+                "PUT",
+                "project/1/views/3",
+                json={"id": 3, "project_id": 1, "title": "updated", "position": 2},
+            )
+
+    def test_delete_view(self, mock_client):
+        """Test delete_view method."""
+        with patch.object(mock_client, "_request", return_value={}) as mock_request:
+            result = mock_client.delete_view(1, 3)
+            assert result == {}
+            mock_request.assert_called_once_with("DELETE", "project/1/views/3")
+
     def test_list_templates_dict_response(self, mock_client):
         """Test list_templates when API returns dict instead of list."""
         mock_response = {"templates": [{"id": 1, "name": "test"}]}

--- a/tests/test_server_coverage.py
+++ b/tests/test_server_coverage.py
@@ -23,6 +23,7 @@ class TestSemaphoreMCPServerCoverage:
         assert server.task_tools is not None
         assert server.environment_tools is not None
         assert server.schedule_tools is not None
+        assert server.view_tools is not None
 
     @patch("semaphore_mcp.server.get_config")
     def test_server_initialization_from_config(self, mock_get_config):
@@ -129,6 +130,7 @@ class TestSemaphoreMCPServerCoverage:
             assert server.task_tools.semaphore == mock_semaphore
             assert server.environment_tools.semaphore == mock_semaphore
             assert server.schedule_tools.semaphore == mock_semaphore
+            assert server.view_tools.semaphore == mock_semaphore
 
     @patch("semaphore_mcp.server.FastMCP")
     def test_fastmcp_initialization(self, mock_fastmcp_class):
@@ -181,6 +183,7 @@ class TestSemaphoreMCPServerCoverage:
             "task_tools",
             "environment_tools",
             "schedule_tools",
+            "view_tools",
         ]
 
         for attr in required_attributes:

--- a/tests/tools/test_views.py
+++ b/tests/tools/test_views.py
@@ -1,0 +1,82 @@
+"""Tests for ViewTools."""
+
+import pytest
+
+
+class TestViewTools:
+    """Test suite for view tool methods."""
+
+    @pytest.mark.asyncio
+    async def test_list_views(self, view_tools, sample_views):
+        """Test list_views method."""
+        project_id = 1
+        view_tools.semaphore.list_views.return_value = sample_views
+
+        result = await view_tools.list_views(project_id)
+
+        assert result == {"views": sample_views}
+        view_tools.semaphore.list_views.assert_called_once_with(project_id)
+
+    @pytest.mark.asyncio
+    async def test_get_view(self, view_tools, sample_views):
+        """Test get_view method."""
+        project_id = 1
+        view_id = 1
+        view_tools.semaphore.get_view.return_value = sample_views[0]
+
+        result = await view_tools.get_view(project_id, view_id)
+
+        assert result == sample_views[0]
+        view_tools.semaphore.get_view.assert_called_once_with(project_id, view_id)
+
+    @pytest.mark.asyncio
+    async def test_create_view(self, view_tools, sample_views):
+        """Test create_view method."""
+        project_id = 1
+        title = "Deployments"
+        position = 1
+        view_tools.semaphore.create_view.return_value = sample_views[0]
+
+        result = await view_tools.create_view(project_id, title, position)
+
+        assert result == sample_views[0]
+        view_tools.semaphore.create_view.assert_called_once_with(
+            project_id, title, position
+        )
+
+    @pytest.mark.asyncio
+    async def test_update_view(self, view_tools):
+        """Test update_view method."""
+        project_id = 1
+        view_id = 2
+        mock_updated = {"id": view_id, "title": "Updated"}
+        view_tools.semaphore.update_view.return_value = mock_updated
+
+        result = await view_tools.update_view(
+            project_id, view_id, title="Updated", position=3
+        )
+
+        assert result == mock_updated
+        view_tools.semaphore.update_view.assert_called_once_with(
+            project_id, view_id, "Updated", 3
+        )
+
+    @pytest.mark.asyncio
+    async def test_delete_view(self, view_tools):
+        """Test delete_view method."""
+        view_tools.semaphore.delete_view.return_value = {}
+
+        result = await view_tools.delete_view(1, 2)
+
+        assert result == {}
+        view_tools.semaphore.delete_view.assert_called_once_with(1, 2)
+
+    @pytest.mark.asyncio
+    async def test_list_views_error(self, view_tools):
+        """Test list_views method with error."""
+        view_tools.semaphore.list_views.side_effect = Exception("API error")
+
+        with pytest.raises(RuntimeError) as excinfo:
+            await view_tools.list_views(1)
+
+        assert "Error during listing views" in str(excinfo.value)


### PR DESCRIPTION
- Add Semaphore project view API methods and MCP tools
- Register and document view CRUD tools
- Add unit/API/server coverage and Docker E2E view CRUD tests
- Add a narrow MCP Inspector retry for transient E2E timeout flakes