### PR TITLE
feat: Add Semaphore project user tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ Once connected, you can interact with SemaphoreUI through natural conversation:
 
 **Projects:** `list_projects`, `get_project`, `create_project`, `update_project`, `delete_project`
 
+**Project users:** `get_project_role`, `list_project_users`, `add_project_user`, `update_project_user`, `remove_project_user`
+
 **Views:** `list_views`, `get_view`, `create_view`, `update_view`, `delete_view`
 
 **Templates:** `list_templates`, `get_template`, `create_template`, `update_template`, `delete_template`

--- a/src/semaphore_mcp/api.py
+++ b/src/semaphore_mcp/api.py
@@ -184,6 +184,55 @@ class SemaphoreAPIClient:
         """
         return self._request("DELETE", f"project/{project_id}")
 
+    # Project user endpoints
+    def get_project_role(self, project_id: int) -> dict[str, Any]:
+        """Get current user's role and permissions for a project."""
+        return self._request("GET", f"project/{project_id}/role")
+
+    def list_project_users(
+        self,
+        project_id: int,
+        sort: str = "name",
+        order: str = "asc",
+    ) -> list[dict[str, Any]]:
+        """List users linked to a project."""
+        result = self._request(
+            "GET",
+            f"project/{project_id}/users",
+            params={"sort": sort, "order": order},
+        )
+        return result if isinstance(result, list) else []
+
+    def add_project_user(
+        self,
+        project_id: int,
+        user_id: int,
+        role: str,
+    ) -> dict[str, Any]:
+        """Link a user to a project with a role."""
+        return self._request(
+            "POST",
+            f"project/{project_id}/users",
+            json={"user_id": user_id, "role": role},
+        )
+
+    def update_project_user(
+        self,
+        project_id: int,
+        user_id: int,
+        role: str,
+    ) -> dict[str, Any]:
+        """Update a linked user's project role."""
+        return self._request(
+            "PUT",
+            f"project/{project_id}/users/{user_id}",
+            json={"role": role},
+        )
+
+    def remove_project_user(self, project_id: int, user_id: int) -> dict[str, Any]:
+        """Remove a user from a project."""
+        return self._request("DELETE", f"project/{project_id}/users/{user_id}")
+
     # View endpoints
     def list_views(self, project_id: int) -> list[dict[str, Any]]:
         """List all views for a project."""

--- a/src/semaphore_mcp/server.py
+++ b/src/semaphore_mcp/server.py
@@ -14,6 +14,7 @@ from .api import create_client
 from .config import configure_logging, get_config
 from .tools.access_keys import AccessKeyTools
 from .tools.environments import EnvironmentTools
+from .tools.project_users import ProjectUserTools
 from .tools.projects import ProjectTools
 from .tools.repositories import RepositoryTools
 from .tools.schedules import ScheduleTools
@@ -55,6 +56,7 @@ class SemaphoreMCPServer:
 
         # Initialize tool classes
         self.project_tools = ProjectTools(self.semaphore)
+        self.project_user_tools = ProjectUserTools(self.semaphore)
         self.template_tools = TemplateTools(self.semaphore)
         self.task_tools = TaskTools(self.semaphore)
         self.environment_tools = EnvironmentTools(self.semaphore)
@@ -74,6 +76,13 @@ class SemaphoreMCPServer:
         self.mcp.tool()(self.project_tools.create_project)
         self.mcp.tool()(self.project_tools.update_project)
         self.mcp.tool()(self.project_tools.delete_project)
+
+        # Project user tools
+        self.mcp.tool()(self.project_user_tools.get_project_role)
+        self.mcp.tool()(self.project_user_tools.list_project_users)
+        self.mcp.tool()(self.project_user_tools.add_project_user)
+        self.mcp.tool()(self.project_user_tools.update_project_user)
+        self.mcp.tool()(self.project_user_tools.remove_project_user)
 
         # View tools
         self.mcp.tool()(self.view_tools.list_views)

--- a/src/semaphore_mcp/tools/__init__.py
+++ b/src/semaphore_mcp/tools/__init__.py
@@ -6,6 +6,7 @@ This package contains tools for interacting with SemaphoreUI through MCP.
 
 from .access_keys import AccessKeyTools
 from .environments import EnvironmentTools
+from .project_users import ProjectUserTools
 from .projects import ProjectTools
 from .repositories import RepositoryTools
 from .schedules import ScheduleTools
@@ -15,6 +16,7 @@ from .views import ViewTools
 
 __all__ = [
     "AccessKeyTools",
+    "ProjectUserTools",
     "ProjectTools",
     "TemplateTools",
     "TaskTools",

--- a/src/semaphore_mcp/tools/project_users.py
+++ b/src/semaphore_mcp/tools/project_users.py
@@ -1,0 +1,135 @@
+"""
+Project user tools for Semaphore MCP.
+
+This module provides tools for managing users linked to SemaphoreUI projects.
+"""
+
+import logging
+from typing import Any
+
+from .base import BaseTool
+
+logger = logging.getLogger(__name__)
+
+PROJECT_USER_ROLES = {"owner", "manager", "task_runner", "guest"}
+PROJECT_USER_SORT_FIELDS = {"name", "username", "email", "role"}
+SORT_ORDERS = {"asc", "desc"}
+
+
+class ProjectUserTools(BaseTool):
+    """Tools for managing users linked to Semaphore projects."""
+
+    def _validate_role(self, role: str) -> None:
+        if role not in PROJECT_USER_ROLES:
+            allowed = ", ".join(sorted(PROJECT_USER_ROLES))
+            raise ValueError(f"role must be one of: {allowed}")
+
+    def _validate_list_options(self, sort: str, order: str) -> None:
+        if sort not in PROJECT_USER_SORT_FIELDS:
+            allowed = ", ".join(sorted(PROJECT_USER_SORT_FIELDS))
+            raise ValueError(f"sort must be one of: {allowed}")
+        if order not in SORT_ORDERS:
+            allowed = ", ".join(sorted(SORT_ORDERS))
+            raise ValueError(f"order must be one of: {allowed}")
+
+    async def get_project_role(self, project_id: int) -> dict[str, Any]:
+        """Get the current user's role and permissions for a project.
+
+        Args:
+            project_id: ID of the project
+
+        Returns:
+            Role and permissions for the current user
+        """
+        try:
+            return self.semaphore.get_project_role(project_id)
+        except Exception as e:
+            self.handle_error(e, f"getting current role for project {project_id}")
+
+    async def list_project_users(
+        self,
+        project_id: int,
+        sort: str = "name",
+        order: str = "asc",
+    ) -> dict[str, Any]:
+        """List users linked to a project.
+
+        Args:
+            project_id: ID of the project
+            sort: Field to sort by: name, username, email, or role
+            order: Sort order: asc or desc
+
+        Returns:
+            Dictionary containing the list of project users
+        """
+        try:
+            self._validate_list_options(sort, order)
+            users = self.semaphore.list_project_users(project_id, sort, order)
+            return {"users": users}
+        except Exception as e:
+            self.handle_error(e, f"listing users for project {project_id}")
+
+    async def add_project_user(
+        self,
+        project_id: int,
+        user_id: int,
+        role: str,
+    ) -> dict[str, Any]:
+        """Link a user to a project with a role.
+
+        Args:
+            project_id: ID of the project
+            user_id: ID of the user to link
+            role: Project role: owner, manager, task_runner, or guest
+
+        Returns:
+            Empty dict on success
+        """
+        try:
+            self._validate_role(role)
+            return self.semaphore.add_project_user(project_id, user_id, role)
+        except Exception as e:
+            self.handle_error(e, f"adding user {user_id} to project {project_id}")
+
+    async def update_project_user(
+        self,
+        project_id: int,
+        user_id: int,
+        role: str,
+    ) -> dict[str, Any]:
+        """Update a linked user's project role.
+
+        Args:
+            project_id: ID of the project
+            user_id: ID of the linked user
+            role: Project role: owner, manager, task_runner, or guest
+
+        Returns:
+            Empty dict on success
+        """
+        try:
+            self._validate_role(role)
+            return self.semaphore.update_project_user(project_id, user_id, role)
+        except Exception as e:
+            self.handle_error(
+                e, f"updating user {user_id} role for project {project_id}"
+            )
+
+    async def remove_project_user(
+        self,
+        project_id: int,
+        user_id: int,
+    ) -> dict[str, Any]:
+        """Remove a user from a project.
+
+        Args:
+            project_id: ID of the project
+            user_id: ID of the user to remove
+
+        Returns:
+            Empty dict on success
+        """
+        try:
+            return self.semaphore.remove_project_user(project_id, user_id)
+        except Exception as e:
+            self.handle_error(e, f"removing user {user_id} from project {project_id}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ import pytest_asyncio
 
 from semaphore_mcp.tools.access_keys import AccessKeyTools
 from semaphore_mcp.tools.environments import EnvironmentTools
+from semaphore_mcp.tools.project_users import ProjectUserTools
 from semaphore_mcp.tools.projects import ProjectTools
 from semaphore_mcp.tools.repositories import RepositoryTools
 from semaphore_mcp.tools.schedules import ScheduleTools
@@ -45,6 +46,12 @@ async def task_tools(mock_semaphore_client):
 async def project_tools(mock_semaphore_client):
     """Create a ProjectTools instance with a mock API client."""
     return ProjectTools(mock_semaphore_client)
+
+
+@pytest_asyncio.fixture
+async def project_user_tools(mock_semaphore_client):
+    """Create a ProjectUserTools instance with a mock API client."""
+    return ProjectUserTools(mock_semaphore_client)
 
 
 @pytest_asyncio.fixture
@@ -142,6 +149,15 @@ def sample_projects():
     return [
         {"id": 1, "name": "Test Project 1"},
         {"id": 2, "name": "Test Project 2"},
+    ]
+
+
+@pytest.fixture
+def sample_project_users():
+    """Standard project user list for testing."""
+    return [
+        {"id": 1, "name": "Admin", "username": "admin", "role": "owner"},
+        {"id": 2, "name": "Operator", "username": "operator", "role": "manager"},
     ]
 
 

--- a/tests/e2e/test_project_users_e2e.py
+++ b/tests/e2e/test_project_users_e2e.py
@@ -1,0 +1,147 @@
+"""E2E tests for project user tools."""
+
+import os
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+import requests
+
+# Add e2e directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent))
+
+from helpers import parse_mcp_response  # noqa: E402
+from mcp_inspector import MCPInspector  # noqa: E402
+
+
+@pytest.fixture
+def semaphore_admin_headers():
+    """Return admin API headers for direct Semaphore setup calls."""
+    token = os.getenv("SEMAPHORE_API_TOKEN")
+    if not token:
+        pytest.skip("SEMAPHORE_API_TOKEN is required for project user E2E setup")
+    return {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+
+
+@pytest.fixture
+def temporary_semaphore_user(semaphore_admin_headers):
+    """Create a temporary global Semaphore user for project membership tests."""
+    semaphore_url = os.getenv("SEMAPHORE_URL", "http://localhost:3000").rstrip("/")
+    suffix = uuid.uuid4().hex[:10]
+    payload = {
+        "name": f"E2E Project User {suffix}",
+        "username": f"e2e-project-user-{suffix}",
+        "email": f"e2e-project-user-{suffix}@localhost",
+        "password": f"E2E-{suffix}-Password-123!",
+        "alert": False,
+        "admin": False,
+        "external": False,
+    }
+
+    response = requests.post(
+        f"{semaphore_url}/api/users",
+        headers=semaphore_admin_headers,
+        json=payload,
+        timeout=30,
+    )
+    response.raise_for_status()
+    user = response.json()
+
+    yield user
+
+    try:
+        requests.delete(
+            f"{semaphore_url}/api/users/{user['id']}/",
+            headers=semaphore_admin_headers,
+            timeout=30,
+        )
+    except Exception:
+        pass
+
+
+class TestProjectUsersE2E:
+    """E2E tests for project user operations."""
+
+    def test_get_project_role(self, inspector: MCPInspector, created_project: dict):
+        """Test getting the current user's project role."""
+        project_id = created_project["id"]
+
+        result = inspector.call_tool("get_project_role", {"project_id": project_id})
+        data = parse_mcp_response(result)
+
+        assert data["role"] == "owner"
+        assert "permissions" in data
+
+    def test_list_project_users(self, inspector: MCPInspector, created_project: dict):
+        """Test listing users linked to a project."""
+        project_id = created_project["id"]
+
+        result = inspector.call_tool(
+            "list_project_users",
+            {"project_id": project_id, "sort": "username", "order": "asc"},
+        )
+        data = parse_mcp_response(result)
+
+        assert "users" in data
+        assert isinstance(data["users"], list)
+        assert any(user["role"] == "owner" for user in data["users"])
+
+    def test_project_user_membership_workflow(
+        self,
+        inspector: MCPInspector,
+        created_project: dict,
+        temporary_semaphore_user: dict,
+    ):
+        """Test adding, updating, listing, and removing a project user."""
+        project_id = created_project["id"]
+        user_id = temporary_semaphore_user["id"]
+        linked = False
+
+        try:
+            add_result = inspector.call_tool(
+                "add_project_user",
+                {"project_id": project_id, "user_id": user_id, "role": "guest"},
+            )
+            assert add_result is not None
+            linked = True
+
+            list_result = inspector.call_tool(
+                "list_project_users",
+                {"project_id": project_id, "sort": "username", "order": "asc"},
+            )
+            users = parse_mcp_response(list_result)["users"]
+            linked_user = next(user for user in users if user["id"] == user_id)
+            assert linked_user["role"] == "guest"
+
+            update_result = inspector.call_tool(
+                "update_project_user",
+                {"project_id": project_id, "user_id": user_id, "role": "manager"},
+            )
+            assert update_result is not None
+
+            list_result = inspector.call_tool(
+                "list_project_users",
+                {"project_id": project_id, "sort": "username", "order": "asc"},
+            )
+            users = parse_mcp_response(list_result)["users"]
+            linked_user = next(user for user in users if user["id"] == user_id)
+            assert linked_user["role"] == "manager"
+
+        finally:
+            if linked:
+                inspector.call_tool(
+                    "remove_project_user",
+                    {"project_id": project_id, "user_id": user_id},
+                )
+
+        list_result = inspector.call_tool(
+            "list_project_users",
+            {"project_id": project_id, "sort": "username", "order": "asc"},
+        )
+        users = parse_mcp_response(list_result)["users"]
+        assert user_id not in [user["id"] for user in users]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/e2e/test_tool_registration.py
+++ b/tests/e2e/test_tool_registration.py
@@ -17,6 +17,12 @@ EXPECTED_TOOLS = {
     "create_project",
     "update_project",
     "delete_project",
+    # Project user tools (5)
+    "get_project_role",
+    "list_project_users",
+    "add_project_user",
+    "update_project_user",
+    "remove_project_user",
     # View tools (5)
     "list_views",
     "get_view",

--- a/tests/test_api_comprehensive.py
+++ b/tests/test_api_comprehensive.py
@@ -87,6 +87,66 @@ class TestSemaphoreAPIClientComprehensive:
             result = mock_client.get_project(1)
             assert result == mock_response
 
+    def test_get_project_role(self, mock_client):
+        """Test get_project_role method."""
+        mock_response = {"role": "owner", "permissions": 0}
+        with patch.object(
+            mock_client, "_request", return_value=mock_response
+        ) as mock_request:
+            result = mock_client.get_project_role(1)
+            assert result == mock_response
+            mock_request.assert_called_once_with("GET", "project/1/role")
+
+    def test_list_project_users_dict_response(self, mock_client):
+        """Test list_project_users when API returns dict instead of list."""
+        mock_response = {"users": [{"id": 1, "role": "owner"}]}
+        with patch.object(mock_client, "_request", return_value=mock_response):
+            result = mock_client.list_project_users(1)
+            assert result == []
+
+    def test_list_project_users_list_response(self, mock_client):
+        """Test list_project_users when API returns list."""
+        mock_response = [{"id": 1, "role": "owner"}]
+        with patch.object(
+            mock_client, "_request", return_value=mock_response
+        ) as mock_request:
+            result = mock_client.list_project_users(1, sort="email", order="desc")
+            assert result == mock_response
+            mock_request.assert_called_once_with(
+                "GET",
+                "project/1/users",
+                params={"sort": "email", "order": "desc"},
+            )
+
+    def test_add_project_user(self, mock_client):
+        """Test add_project_user method."""
+        with patch.object(mock_client, "_request", return_value={}) as mock_request:
+            result = mock_client.add_project_user(1, 2, "guest")
+            assert result == {}
+            mock_request.assert_called_once_with(
+                "POST",
+                "project/1/users",
+                json={"user_id": 2, "role": "guest"},
+            )
+
+    def test_update_project_user(self, mock_client):
+        """Test update_project_user method."""
+        with patch.object(mock_client, "_request", return_value={}) as mock_request:
+            result = mock_client.update_project_user(1, 2, "manager")
+            assert result == {}
+            mock_request.assert_called_once_with(
+                "PUT",
+                "project/1/users/2",
+                json={"role": "manager"},
+            )
+
+    def test_remove_project_user(self, mock_client):
+        """Test remove_project_user method."""
+        with patch.object(mock_client, "_request", return_value={}) as mock_request:
+            result = mock_client.remove_project_user(1, 2)
+            assert result == {}
+            mock_request.assert_called_once_with("DELETE", "project/1/users/2")
+
     def test_list_views_dict_response(self, mock_client):
         """Test list_views when API returns dict instead of list."""
         mock_response = {"views": [{"id": 1, "title": "deployments"}]}

--- a/tests/test_server_coverage.py
+++ b/tests/test_server_coverage.py
@@ -19,6 +19,7 @@ class TestSemaphoreMCPServerCoverage:
         assert server.token == "test-token"
         assert server.semaphore is not None
         assert server.project_tools is not None
+        assert server.project_user_tools is not None
         assert server.template_tools is not None
         assert server.task_tools is not None
         assert server.environment_tools is not None
@@ -126,6 +127,7 @@ class TestSemaphoreMCPServerCoverage:
 
             # Verify all tool classes received the same semaphore client
             assert server.project_tools.semaphore == mock_semaphore
+            assert server.project_user_tools.semaphore == mock_semaphore
             assert server.template_tools.semaphore == mock_semaphore
             assert server.task_tools.semaphore == mock_semaphore
             assert server.environment_tools.semaphore == mock_semaphore
@@ -179,6 +181,7 @@ class TestSemaphoreMCPServerCoverage:
             "semaphore",
             "mcp",
             "project_tools",
+            "project_user_tools",
             "template_tools",
             "task_tools",
             "environment_tools",

--- a/tests/tools/test_project_users.py
+++ b/tests/tools/test_project_users.py
@@ -1,0 +1,100 @@
+"""Tests for ProjectUserTools."""
+
+import pytest
+
+
+class TestProjectUserTools:
+    """Test suite for project user tool methods."""
+
+    @pytest.mark.asyncio
+    async def test_get_project_role(self, project_user_tools):
+        """Test get_project_role method."""
+        project_user_tools.semaphore.get_project_role.return_value = {
+            "role": "owner",
+            "permissions": 0,
+        }
+
+        result = await project_user_tools.get_project_role(1)
+
+        assert result == {"role": "owner", "permissions": 0}
+        project_user_tools.semaphore.get_project_role.assert_called_once_with(1)
+
+    @pytest.mark.asyncio
+    async def test_list_project_users(self, project_user_tools, sample_project_users):
+        """Test list_project_users method."""
+        project_user_tools.semaphore.list_project_users.return_value = (
+            sample_project_users
+        )
+
+        result = await project_user_tools.list_project_users(
+            1, sort="username", order="desc"
+        )
+
+        assert result == {"users": sample_project_users}
+        project_user_tools.semaphore.list_project_users.assert_called_once_with(
+            1, "username", "desc"
+        )
+
+    @pytest.mark.asyncio
+    async def test_add_project_user(self, project_user_tools):
+        """Test add_project_user method."""
+        project_user_tools.semaphore.add_project_user.return_value = {}
+
+        result = await project_user_tools.add_project_user(1, 2, "guest")
+
+        assert result == {}
+        project_user_tools.semaphore.add_project_user.assert_called_once_with(
+            1, 2, "guest"
+        )
+
+    @pytest.mark.asyncio
+    async def test_update_project_user(self, project_user_tools):
+        """Test update_project_user method."""
+        project_user_tools.semaphore.update_project_user.return_value = {}
+
+        result = await project_user_tools.update_project_user(1, 2, "manager")
+
+        assert result == {}
+        project_user_tools.semaphore.update_project_user.assert_called_once_with(
+            1, 2, "manager"
+        )
+
+    @pytest.mark.asyncio
+    async def test_remove_project_user(self, project_user_tools):
+        """Test remove_project_user method."""
+        project_user_tools.semaphore.remove_project_user.return_value = {}
+
+        result = await project_user_tools.remove_project_user(1, 2)
+
+        assert result == {}
+        project_user_tools.semaphore.remove_project_user.assert_called_once_with(1, 2)
+
+    @pytest.mark.asyncio
+    async def test_add_project_user_rejects_invalid_role(self, project_user_tools):
+        """Test add_project_user validates role."""
+        with pytest.raises(RuntimeError) as excinfo:
+            await project_user_tools.add_project_user(1, 2, "admin")
+
+        assert "role must be one of" in str(excinfo.value)
+        project_user_tools.semaphore.add_project_user.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_list_project_users_rejects_invalid_sort(self, project_user_tools):
+        """Test list_project_users validates sort."""
+        with pytest.raises(RuntimeError) as excinfo:
+            await project_user_tools.list_project_users(1, sort="created")
+
+        assert "sort must be one of" in str(excinfo.value)
+        project_user_tools.semaphore.list_project_users.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_list_project_users_error(self, project_user_tools):
+        """Test list_project_users method with error."""
+        project_user_tools.semaphore.list_project_users.side_effect = Exception(
+            "API error"
+        )
+
+        with pytest.raises(RuntimeError) as excinfo:
+            await project_user_tools.list_project_users(1)
+
+        assert "Error during listing users" in str(excinfo.value)


### PR DESCRIPTION
- Add project role and project user membership API methods
- Add MCP tools for listing, adding, updating, and removing project users
- Register and document project user tools
- Add unit/API/server coverage and Docker E2E membership workflow